### PR TITLE
Check with newer unique id of the C# extension

### DIFF
--- a/src/utils/extensionUtil.ts
+++ b/src/utils/extensionUtil.ts
@@ -9,7 +9,7 @@ import { openUrl } from '../utils/openUrl';
 
 // tslint:disable-next-line:export-name
 export function checkCsharpExtensionInstalled(actionContext: IActionContext): void {
-    const csharpExtension = vscode.extensions.getExtension("ms-vscode.csharp");
+    const csharpExtension = vscode.extensions.getExtension("ms-dotnettools.csharp") || vscode.extensions.getExtension("ms-vscode.csharp");
     if (!csharpExtension) {
         const message: string = localize('csharpExtensionNotInstalled', 'You must have the VSCode CSharp extension installed to improve policy authoring experience.');
 


### PR DESCRIPTION
The Unique ID of the C# extension has been changed for the newer versions as mentioned [here](https://github.com/OmniSharp/omnisharp-vscode#whats-new-in-12113).

Added a check for the newer one, leaving the check for the old one intact for users who might have not upgraded yet.