### PR TITLE
Fix pipelines badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Version](https://vsmarketplacebadge.apphb.com/version/ms-azuretools.vscode-apimanagement.svg)](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-apimanagement) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/ms-azuretools.vscode-apimanagement.svg)](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-apimanagement)
-[![Build Status](https://dev.azure.com/ms-azuretools/AzCode/_apis/build/status/Nightly/vscode-apimanagement-nightly?branchName=master)](https://dev.azure.com/ms-azuretools/AzCode/_build/latest?definitionId=21&branchName=master) [![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/Microsoft/vscode-apimanagement/blob/master/LICENSE.md)
+[![Build Status](https://dev.azure.com/ms-azuretools/AzCode/_apis/build/status/vscode-apimanagement?branchName=master)](https://dev.azure.com/ms-azuretools/AzCode/_build/latest?definitionId=20&branchName=master) [![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/Microsoft/vscode-apimanagement/blob/master/LICENSE.md)
 
 # Azure API Management Extension for Visual Studio Code (Preview)
 


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-apimanagement/pull/79 was consolidating the nightly and non-nightly build definitions, which means the current badge doesn't work.