### PR TITLE
Fix API version set operation url

### DIFF
--- a/src/operationConsole/OperationConsole.ts
+++ b/src/operationConsole/OperationConsole.ts
@@ -58,7 +58,7 @@ export class OperationConsole {
         let versionPath = "";
         let revision = "";
 
-        if (api.apiVersionSet && api.apiVersion && api.apiVersionSet.versioningScheme === "Segment") {
+        if (api.apiVersion) {
             versionPath = `/${api.apiVersion}`;
         }
 


### PR DESCRIPTION
original API:
![image](https://user-images.githubusercontent.com/29927264/79014121-16815a00-7b1f-11ea-9f54-e841e5ddc62f.png)
v1 API:
![image](https://user-images.githubusercontent.com/29927264/79014169-2e58de00-7b1f-11ea-84d5-419ec2701548.png)
Api.Apiversionset doesn't exist always, we need to add the apiVersion