### PR TITLE
Fixed typo SusbscriptionKey

### DIFF
--- a/src/operationConsole/ConsoleRequest.ts
+++ b/src/operationConsole/ConsoleRequest.ts
@@ -39,7 +39,7 @@ export class ConsoleRequest {
 
         const keyHeader = new ConsoleHeader();
         keyHeader.name = "Ocp-Apim-Subscription-Key";
-        keyHeader.value = "{{SusbscriptionKey}}";
+        keyHeader.value = "{{SubscriptionKey}}";
         this.headers.push(keyHeader);
 
         const traceHeader = new ConsoleHeader();


### PR DESCRIPTION
SusbscriptionKey renamed to SubscriptionKey to avoid further
downstream problems because of the typo. For example when referring
to REST Client variables inline or in environment settings.