### PR TITLE
Generating debug session key and matching it on every debug message

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,15 +90,7 @@
                 "NODE_DEBUG": "",
                 "ENABLE_LONG_RUNNING_TESTS": ""
             }
-        },
-        {
-			"type": "node",
-			"request": "launch",
-			"name": "Server",
-			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/resources/debug/debugAdapter.js",
-			"args": [ "--server=4711" ]
-		},
+        }
     ],
     "compounds": [
 		{

--- a/src/debugger/apimDebug.ts
+++ b/src/debugger/apimDebug.ts
@@ -45,7 +45,7 @@ export class ApimDebugSession extends LoggingDebugSession {
 	private policySource: PolicySource;
 	private variablesHandles = new Handles<string>();
 
-	public constructor() {
+	public constructor(private sessionKey: string) {
 		super();
 
 		this.setDebuggerLinesStartAt1(false);
@@ -79,6 +79,16 @@ export class ApimDebugSession extends LoggingDebugSession {
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
 		super.configurationDoneRequest(response, args);
 		this.configurationDone.notify();
+	}
+
+	public handleMessage(request: DebugProtocol.Request): void {
+		// If request came from VSCode there must be session key present, if not - ignore the message
+		if (this.sessionKey !== request.arguments?._sessionKey) {
+			return;
+		}
+
+		delete request.arguments._sessionKey;
+		super.handleMessage(request);
 	}
 
 	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArguments): Promise<void> {

--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -1,7 +1,0 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
-
- import { ApimDebugSession } from './apimDebug';
-
- ApimDebugSession.run(ApimDebugSession);

--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -4,6 +4,7 @@ import * as Net from 'net';
 import * as vscode from 'vscode';
 import { CancellationToken, DebugConfiguration, ProviderResult, WorkspaceFolder } from 'vscode';
 import { ApimDebugSession } from './apimDebug';
+import * as Crypto from 'crypto';
 
 // tslint:disable: no-unsafe-any
 // tslint:disable: indent
@@ -21,6 +22,8 @@ export function activate(context: vscode.ExtensionContext) {
     const factory = new ApimPolicyDebugAdapterDescriptorFactory();
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('apim-policy', factory));
     context.subscriptions.push(factory);
+
+    context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory('apim-policy', new ApimPolicyDebugSessionKeyAppenderFactory()));
 }
 
 export function deactivate() {}
@@ -36,23 +39,52 @@ class ApimPolicyConfigurationProvider implements vscode.DebugConfigurationProvid
                 config.stopOnEntry = true;
             }
         }
+
         return config;
     }
 }
 
-class ApimPolicyDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+class ApimPolicyDebugSessionKeyAppenderFactory implements vscode.DebugAdapterTrackerFactory {
+    createDebugAdapterTracker(session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterTracker> {
+        return new ApimPolicyDebugSessionKeyAppender(session);
+    }
+}
 
+class ApimPolicyDebugSessionKeyAppender implements vscode.DebugAdapterTracker {
+    private sessionKey: string;
+
+    constructor(_session: vscode.DebugSession) {
+        this.sessionKey = _session.configuration.key;
+    }
+
+    onWillReceiveMessage(message: any) {
+        if (!message.arguments) {
+            message.arguments = {};
+        }
+
+        //Append the session key to every message we send
+        message.arguments._sessionKey = this.sessionKey;
+    }
+}
+
+class ApimPolicyDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
     private server?: Net.Server;
+    private serverKey: string;
 
     public createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
         if (!this.server) {
+            // generate a random key for further the debug sessions
+            this.serverKey = Crypto.randomBytes(16).toString('hex');
+
             // start listening on a random port
             this.server = Net.createServer(socket => {
-                const session = new ApimDebugSession();
+                const session = new ApimDebugSession(this.serverKey);
                 session.setRunAsServer(true);
                 session.start(<NodeJS.ReadableStream>socket, socket);
             }).listen(0);
         }
+
+        _session.configuration.key = this.serverKey;
 
         // make VS Code connect to debug server
         return new vscode.DebugAdapterServer(this.server.address().port);


### PR DESCRIPTION
Ensuring that DAP will only process messages sent by VSCode.