### PR TITLE
chore: Use VSCode engine 1.68 (May 2022)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/apim-icon-newone.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.31.0"
+        "vscode": "^1.68.0"
     },
     "categories": [
         "Azure"


### PR DESCRIPTION
Use VSCode engine 1.68 (May 2022) to be more up-to-date, similar to partner teams (who are often more aggressive):
- https://github.com/microsoft/powerplatform-vscode/blob/main/package.json#L54
- https://github.com/microsoft/vscode-azurecontainerapps/blob/main/package.json#L10
- https://github.com/microsoft/vscode-azurelogicapps/blob/main/package.json#L10
- https://github.com/microsoft/vscode-azureresourcegroups/blob/main/package.json#L10
- https://github.com/microsoft/vscode-azurefunctions/blob/main/package.json#L10
- https://github.com/microsoft/vscode-docker/blob/main/package.json#L2888