### PR TITLE
ci: Only run CI for pushes to master branch and PRs

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -33,7 +33,7 @@ jobs:
 trigger:
   branches:
     include:
-    - '*'
+    - 'master'
 
 pr:
   branches:


### PR DESCRIPTION
Only run CI for pushes to master branch and PRs, not for every single push to any branch.