### PR TITLE
chore: overriding the version for fsevents package, VSCode engine to 1.50.1 *September 2020 Recovery)

### DIFF
--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -7,6 +7,10 @@ steps:
 - task: Npm@1
   displayName: 'npm install'
 
+- script: npm install
+  displayName: 'npm install (script)'
+  condition: always()
+
 - task: Npm@1
   displayName: 'Build'
   inputs:

--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -4,12 +4,12 @@ steps:
   inputs:
     versionSpec: 16.x
 
-- task: Npm@1
-  displayName: 'npm install'
-
 - script: npm install
   displayName: 'npm install (script)'
   condition: always()
+
+- task: Npm@1
+  displayName: 'npm install'
 
 - task: Npm@1
   displayName: 'Build'

--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -7,6 +7,7 @@ steps:
 - script: npm install
   displayName: 'npm install (script)'
   condition: always()
+  continueOnError: true
 
 - task: Npm@1
   displayName: 'npm install'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-apimanagement",
     "displayName": "Azure API Management",
     "description": "An Azure API Management extension for Visual Studio Code.",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "publisher": "ms-azuretools",
     "icon": "resources/apim-icon-newone.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/package.json
+++ b/package.json
@@ -873,5 +873,8 @@
     "extensionDependencies": [
         "ms-vscode.azure-account",
         "humao.rest-client"
-    ]
+    ],
+    "overrides": {
+        "fsevents": "~2.3.2"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/apim-icon-newone.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.31.0"
+        "vscode": "^1.50.1"
     },
     "categories": [
         "Azure"


### PR DESCRIPTION
Overriding fsevents
adding extra step for npm install as it is flaky on MacOS 
upgrading VS Code engine