### PR TITLE
extractor: require only .NET runtime and allow any version higher than 2.1

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -63,7 +63,7 @@ async function extract(node: ApiTreeItem | ServiceTreeItem, apiName?: string): P
         },
         async () => {
             await azUtils.checkAzInstalled();
-            await dotnetUtils.checkDotnetInstalled();
+            await dotnetUtils.validateDotnetInstalled();
             await runExtractor(configFile, subscriptionId);
         }
     ).then(
@@ -104,20 +104,16 @@ async function runExtractor(filePath: string, subscriptionId: string): Promise<v
         subscriptionId
     );
 
-    if (await dotnetUtils.checkDotnetVersionInstalled("2.1")) {
-        await cpUtils.executeCommand(
-            ext.outputChannel,
-            workingFolderPath,
-            'dotnet',
-            'apimtemplate.dll',
-            'extract',
-            '--extractorConfig',
-            `"${filePath}"`
-        );
-    } else {
-        window.showInformationMessage(localize("dotnetNotInstalled", ".NET framework 2.1 not installed. Please go to 'https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.1.0&arch=x64&rid=win10-x64' to download"));
-        throw new Error();
-    }
+    await dotnetUtils.validateDotnetInstalled();
+    await cpUtils.executeCommand(
+        ext.outputChannel,
+        workingFolderPath,
+        'dotnet',
+        'apimtemplate.dll',
+        'extract',
+        '--extractorConfig',
+        `"${filePath}"`
+    );
 }
 
 async function askFolder(): Promise<Uri[]> {

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -14,11 +14,12 @@ export namespace dotnetUtils {
         try {
             await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--version');
             return true;
-        } catch (error) { }
-        return false;
+        } catch (error) {
+            return false;
+        }
     }
 
-    export async function validateDotnetInstalled(actionContext?: IActionContext, minVersion = "2.1"): Promise<void> {
+    export async function validateDotnetInstalled(actionContext?: IActionContext, minVersion: string = "2.1"): Promise<void> {
         if (!await isDotnetInstalled() || !await checkDotnetVersionInstalled(minVersion)) {
             const message: string = localize('dotnetNotInstalled', 'You must have the .NET CLI {0} or older installed to perform this operation.', minVersion);
 
@@ -29,22 +30,23 @@ export namespace dotnetUtils {
                         await openUrl('https://aka.ms/AA4ac70');
                     }
                 });
-                if (actionContext)
+                if (actionContext) {
                     actionContext.errorHandling.suppressDisplay = true;
+                }
             }
 
             throw new Error(message);
         }
     }
 
-    function compareVersion(version1: string, version2: string) {
-        let v1 = version1.split('.').map(v => parseInt(v));
-        let v2 = version2.split('.').map(v => parseInt(v));
+    function compareVersion(version1: string, version2: string): number {
+        const v1 = version1.split('.').map(parseInt);
+        const v2 = version2.split('.').map(parseInt);
         for (let i = 0; i < Math.min(v1.length, v2.length); i++) {
-            if (v1[i] > v2[i]) return 1;
-            if (v1[i] < v2[i]) return -1;        
+            if (v1[i] > v2[i]) { return 1; }
+            if (v1[i] < v2[i]) { return -1; }
         }
-        return v1.length == v2.length ? 0: (v1.length < v2.length ? -1 : 1);
+        return v1.length === v2.length ? 0 : (v1.length < v2.length ? -1 : 1);
     }
 
     async function checkDotnetVersionInstalled(minVersion: string): Promise<boolean> {
@@ -52,12 +54,14 @@ export namespace dotnetUtils {
             const response = await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--list-runtimes');
             const versions = response.split(/\r?\n/);
             for (const version of versions) {
-                let versionNumber = version.split(' ')[1];
+                const versionNumber = version.split(' ')[1];
                 if (compareVersion(versionNumber, minVersion) >= 0) {
                     return false;
                 }
             }
-        } catch (error) { }
+        } catch (error) {
+            return false;
+        }
         return false;
     }
 }

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -14,52 +14,50 @@ export namespace dotnetUtils {
         try {
             await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--version');
             return true;
-        } catch (error) {
-            return false;
-        }
+        } catch (error) { }
+        return false;
     }
 
-    export async function validateDotnetInstalled(actionContext: IActionContext): Promise<void> {
-        if (!await isDotnetInstalled()) {
-            const message: string = localize('dotnetNotInstalled', 'You must have the .NET CLI installed to perform this operation.');
+    export async function validateDotnetInstalled(actionContext?: IActionContext, minVersion = "2.1"): Promise<void> {
+        if (!await isDotnetInstalled() || !await checkDotnetVersionInstalled(minVersion)) {
+            const message: string = localize('dotnetNotInstalled', 'You must have the .NET CLI {0} or older installed to perform this operation.', minVersion);
 
-            if (!actionContext.errorHandling.suppressDisplay) {
+            if (!actionContext || !actionContext.errorHandling.suppressDisplay) {
                 // don't wait
                 vscode.window.showErrorMessage(message, DialogResponses.learnMore).then(async (result) => {
                     if (result === DialogResponses.learnMore) {
                         await openUrl('https://aka.ms/AA4ac70');
                     }
                 });
-                actionContext.errorHandling.suppressDisplay = true;
+                if (actionContext)
+                    actionContext.errorHandling.suppressDisplay = true;
             }
 
             throw new Error(message);
         }
     }
 
-    export async function checkDotnetInstalled(): Promise<void> {
-        if (!await isDotnetInstalled()) {
-            const message: string = localize('dotnetNotInstalled', 'You must have a .NET Core SDK v2.1.x CLI installed to perform this operation.');
+    function compareVersion(version1: string, version2: string) {
+        let v1 = version1.split('.').map(v => parseInt(v));
+        let v2 = version2.split('.').map(v => parseInt(v));
+        for (let i = 0; i < Math.min(v1.length, v2.length); i++) {
+            if (v1[i] > v2[i]) return 1;
+            if (v1[i] < v2[i]) return -1;        
+        }
+        return v1.length == v2.length ? 0: (v1.length < v2.length ? -1 : 1);
+    }
 
-            // don't wait
-            vscode.window.showErrorMessage(message, DialogResponses.learnMore).then(async (result) => {
-                if (result === DialogResponses.learnMore) {
-                    await openUrl('https://aka.ms/AA4ac70');
+    async function checkDotnetVersionInstalled(minVersion: string): Promise<boolean> {
+        try {
+            const response = await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--list-runtimes');
+            const versions = response.split(/\r?\n/);
+            for (const version of versions) {
+                let versionNumber = version.split(' ')[1];
+                if (compareVersion(versionNumber, minVersion) >= 0) {
+                    return false;
                 }
-            });
-
-            throw new Error(message);
-        }
-    }
-
-    export async function checkDotnetVersionInstalled(targetVersion: string): Promise<boolean> {
-        const response = await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--list-sdks');
-        const versions = response.split(/\r?\n/);
-        for (const version of versions) {
-            if (version.startsWith(targetVersion)) {
-                return true;
             }
-        }
+        } catch (error) { }
         return false;
     }
 }


### PR DESCRIPTION
Refactor .NET runtime installation check. Require only runtime (not SDK) and allow any version higher than 2.1 (previously require 2.1 strictly)