### PR TITLE
Updates the APIM API version to 2024-05-01

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export enum HttpTriggerDirectionContract {
 export const HttpTriggerAuthLevelAdmin = "admin";
 export const FunctionAppKeyLength = 40;
 export const webAppApiVersion20190801 = "2019-08-01";
-export const apimApiVersion = "2019-12-01";
+export const apimApiVersion = "2021-08-01";
 export const maxTokenValidTimeSpan = 29;
 export const gatewayHostName = "CustomerHostName";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export enum HttpTriggerDirectionContract {
 export const HttpTriggerAuthLevelAdmin = "admin";
 export const FunctionAppKeyLength = 40;
 export const webAppApiVersion20190801 = "2019-08-01";
-export const apimApiVersion = "2021-08-01";
+export const apimApiVersion = "2024-05-01";
 export const maxTokenValidTimeSpan = 29;
 export const gatewayHostName = "CustomerHostName";
 


### PR DESCRIPTION
This is used when communicating to the management API of APIM All versions prior to 2021-08-01 are deprecated and will be phased out starting 1st June 2024.
This is documented here > https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/api-version-retirement-sep-2023

The advice to APIM maintainers has been to set the minimum supported API version to 2021-08-01 (see above link).
This extension cannot then communicate with those APIMs unless the minified constants.js is manually updated locally.

Fixes #352 #346 #317 #343 #357 #358