### PR TITLE
build: align vscode type version with engine requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "@types/request-promise": "^4.1.46",
                 "@types/request-promise-native": "^1.0.17",
                 "@types/swagger-parser": "^4.0.3",
-                "@types/vscode": "^1.96.0",
+                "@types/vscode": "^1.50.1",
                 "@types/ws": "^6.0.4",
                 "@vscode/test-cli": "^0.0.10",
                 "@vscode/test-electron": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -828,7 +828,7 @@
         "@types/request-promise": "^4.1.46",
         "@types/request-promise-native": "^1.0.17",
         "@types/swagger-parser": "^4.0.3",
-        "@types/vscode": "^1.96.0",
+        "@types/vscode": "^1.50.1",
         "@types/ws": "^6.0.4",
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.4.1",


### PR DESCRIPTION
The version of `@types/vscode` should align with the supported vscode engine version in package.json. Align their versions in this PR.