### PR TITLE
build: update service connection in release pipeline

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -48,7 +48,7 @@ extends:
     additionalSetupSteps: 
       - pwsh: |
           echo Updating aikey in package.json
-          (Get-Content package.json) -replace '"aikey": ".*"', '"aikey": "$(PRODUCTION_AI_KEY)"' | Set-Content package.json
+          (Get-Content package.json) -replace '"aiKey": ".*"', '"aiKey": "$(PRODUCTION_AI_KEY)"' | Set-Content package.json
         displayName: Update aikey in package.json
         env:
           PRODUCTION_AI_KEY: $(PRODUCTION_AI_KEY)

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -18,7 +18,7 @@ resources:
       type: github
       name: microsoft/vscode-azuretools
       ref: main
-      endpoint: GitHub-AzureTools
+      endpoint: GitHub-chyuan
 
 variables:
   # Required by MicroBuild template


### PR DESCRIPTION
Per Azure Tools team, we need to use our own service connection to access the microsoft/vscode-azuretools repo, which stores the shared release pipeline template.
Also fix a case issue in app insights key replacement.