### PR TITLE
feat: use older API version to improve compatibility with Consumption tier

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export enum HttpTriggerDirectionContract {
 export const HttpTriggerAuthLevelAdmin = "admin";
 export const FunctionAppKeyLength = 40;
 export const webAppApiVersion20190801 = "2019-08-01";
-export const apimApiVersion = "2024-06-01-preview";
+export const apimApiVersion = "2022-08-01";
 export const maxTokenValidTimeSpan = 29;
 export const gatewayHostName = "CustomerHostName";
 


### PR DESCRIPTION
The consumption tier APIM does not support latest API version. Use older API version to improve the compatibility. `2022-08-01` is the latest stable API version supported by consumption tier per the error message.