### PR TITLE
build: use key of new App Insights test instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.0.10",
     "publisher": "ms-azuretools",
     "icon": "resources/apim-icon-newone.png",
-    "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+    "aiKey": "cbd849ca-06a5-4aef-bc27-08e37b251d1b",
     "engines": {
         "vscode": "^1.50.1"
     },


### PR DESCRIPTION
Use the key of new App Insights test instance `telemetry-apim-testing`
The production key will be replaced dynamically during build.