### PR TITLE
feat: copy selected subscription key

### DIFF
--- a/package.json
+++ b/package.json
@@ -571,6 +571,10 @@
                 {
                     "command": "azureApiManagement.LoadMore",
                     "when": "never"
+                },
+                {
+                    "command": "azureApiManagement.copySubscriptionKeyValue",
+                    "when": "never"
                 }
             ],
             "view/title": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "onCommand:azureApiManagement.createService",
         "onCommand:azureApiManagement.deleteService",
         "onCommand:azureApiManagement.copySubscriptionKey",
+        "onCommand:azureApiManagement.copySubscriptionKeyValue",
         "onCommand:azureApiManagement.deleteApi",
         "onCommand:azureApiManagement.deleteOperation",
         "onCommand:azureApiManagement.importOpenApiByFile",
@@ -226,6 +227,11 @@
             {
                 "command": "azureApiManagement.copySubscriptionKey",
                 "title": "%azureApiManagement.copySubscriptionKey%",
+                "category": "Azure API Management"
+            },
+            {   
+                "command": "azureApiManagement.copySubscriptionKeyValue",
+                "title": "%azureApiManagement.copySubscriptionKeyValue%",
                 "category": "Azure API Management"
             },
             {
@@ -769,6 +775,11 @@
                     "command": "azureApiManagement.deleteSubscription",
                     "when": "view == azureApiManagementExplorer && viewItem == azureApiManagementSubscriptionTreeItem",
                     "group": "1@1"
+                },
+                {
+                    "command": "azureApiManagement.copySubscriptionKeyValue",
+                    "when": "view == azureApiManagementExplorer && viewItem == azureApiManagementSubscriptionTreeItem",
+                    "group": "1@0"
                 },
                 {
                     "command": "azureApiManagement.createAuthorizationProvider",

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,7 @@
     "azureApiManagement.createService": "Create API Management in Azure",
     "azureApiManagement.deleteService": "Delete API Management",
     "azureApiManagement.copySubscriptionKey" : "Copy Subscription Key",
+    "azureApiManagement.copySubscriptionKeyValue" : "Copy Subscription Key",
     "azureApiManagement.showApi": "Edit OpenAPI",
     "azureApiManagement.showArmApi": "Edit API",
     "azureApiManagement.showArmApiOperation": "Edit Operation",

--- a/src/commands/copySubscriptionKeyValue.ts
+++ b/src/commands/copySubscriptionKeyValue.ts
@@ -41,6 +41,10 @@ export async function copySubscriptionKeyValue(context: IActionContext, node?: S
                 ],
                 { placeHolder: 'Select which subscription key to copy' }
             );
+            if (!selection) {
+                // User canceled the QuickPick
+                return;
+            }
             keyToCopy = selection.key;
         } else {
             // Use whichever key is available

--- a/src/commands/copySubscriptionKeyValue.ts
+++ b/src/commands/copySubscriptionKeyValue.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { SubscriptionTreeItem } from '../explorer/SubscriptionTreeItem';
+import { ext } from '../extensionVariables';
+import { localize } from '../localize';
+
+export async function copySubscriptionKeyValue(context: IActionContext, node?: SubscriptionTreeItem): Promise<void> {
+    if (!node) {
+        node = <SubscriptionTreeItem>await ext.tree.showTreeItemPicker(SubscriptionTreeItem.contextValue, context);
+    }
+    
+    try {
+        // Get the subscription keys
+        const subscriptionKeys = await node.root.client.subscription.listSecrets(
+            node.root.resourceGroupName, 
+            node.root.serviceName, 
+            node.root.subscriptionSid
+        );
+        
+        // Choose which key to copy - by default use primary
+        if (!subscriptionKeys.primaryKey && !subscriptionKeys.secondaryKey) {
+            throw new Error(localize("NoSubscriptionKeys", "No subscription keys are available."));
+        }
+        
+        const primaryKeyAvailable = !!subscriptionKeys.primaryKey;
+        const secondaryKeyAvailable = !!subscriptionKeys.secondaryKey;
+        
+        // If both keys are available, ask which one to copy
+        let keyToCopy: string | undefined;
+        
+        if (primaryKeyAvailable && secondaryKeyAvailable) {
+            const selection = await context.ui.showQuickPick(
+                [
+                    { label: 'Primary Key', key: subscriptionKeys.primaryKey },
+                    { label: 'Secondary Key', key: subscriptionKeys.secondaryKey }
+                ],
+                { placeHolder: 'Select which subscription key to copy' }
+            );
+            keyToCopy = selection.key;
+        } else {
+            // Use whichever key is available
+            keyToCopy = subscriptionKeys.primaryKey || subscriptionKeys.secondaryKey;
+        }
+        
+        if (!keyToCopy) {
+            throw new Error(localize("CopySubscriptionKey", "Could not find a valid subscription key."));
+        }
+        
+        // Copy the key to clipboard
+        await vscode.env.clipboard.writeText(keyToCopy);
+        vscode.window.showInformationMessage(localize("SubscriptionKeyCopied", "Subscription key has been copied to clipboard."));
+    } catch (error) {
+        vscode.window.showErrorMessage(localize("ErrorCopyingSubscriptionKey", `Error copying subscription key: ${error instanceof Error ? error.message : String(error)}`));
+        throw error;
+    }
+}

--- a/src/commands/copySubscriptionKeyValue.ts
+++ b/src/commands/copySubscriptionKeyValue.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { IActionContext, isUserCancelledError } from '@microsoft/vscode-azext-utils';
 import { SubscriptionTreeItem } from '../explorer/SubscriptionTreeItem';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
@@ -41,10 +41,6 @@ export async function copySubscriptionKeyValue(context: IActionContext, node?: S
                 ],
                 { placeHolder: 'Select which subscription key to copy' }
             );
-            if (!selection) {
-                // User canceled the QuickPick
-                return;
-            }
             keyToCopy = selection.key;
         } else {
             // Use whichever key is available
@@ -59,6 +55,10 @@ export async function copySubscriptionKeyValue(context: IActionContext, node?: S
         await vscode.env.clipboard.writeText(keyToCopy);
         vscode.window.showInformationMessage(localize("SubscriptionKeyCopied", "Subscription key has been copied to clipboard."));
     } catch (error) {
+        if (isUserCancelledError(error)) {
+            // User cancelled the operation, do nothing
+            return;
+        }
         vscode.window.showErrorMessage(localize("ErrorCopyingSubscriptionKey", `Error copying subscription key: ${error instanceof Error ? error.message : String(error)}`));
         throw error;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { createAuthorization } from './commands/authorizations/createAuthorizati
 import { createAuthorizationAccessPolicy } from './commands/authorizations/createAuthorizationAccessPolicy';
 import { createAuthorizationProvider } from './commands/authorizations/createAuthorizationProvider';
 import { copySubscriptionKey } from './commands/copySubscriptionKey';
+import { copySubscriptionKeyValue } from './commands/copySubscriptionKeyValue';
 import { createService } from './commands/createService';
 import { debugPolicy } from './commands/debugPolicies/debugPolicy';
 import { deleteNode } from './commands/deleteNode';
@@ -157,6 +158,7 @@ function registerCommands(tree: AzExtTreeDataProvider): void {
     registerCommand('azureApiManagement.createService', createService);
     registerCommand('azureApiManagement.showWalkthrough', async () => { await vscode.commands.executeCommand('workbench.action.openWalkthrough', 'ms-azuretools.vscode-apimanagement#apim-import-and-test-apis'); });
     registerCommand('azureApiManagement.copySubscriptionKey', copySubscriptionKey);
+    registerCommand('azureApiManagement.copySubscriptionKeyValue', copySubscriptionKeyValue);
     registerCommand('azureApiManagement.deleteService', async (context: IActionContext, node?: AzExtParentTreeItem) => await deleteNode(context, ServiceTreeItem.contextValue, node));
     registerCommand('azureApiManagement.deleteApi', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, ApiTreeItem.contextValue, node));
     registerCommand('azureApiManagement.deleteOperation', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, ApiOperationTreeItem.contextValue, node));


### PR DESCRIPTION
Add `Copy Subscription Key` menu to Subscription Key tree view node. So users can copy any subscription key.

There's also a `Copy Subscription Key` menu on the APIM instance tree view node. I'm syncing with PM about how to deprecate this menu smoothly.

UT will be added later due to the `@vscode/test-electron` timeout issue.

![copy-subscription-key](https://github.com/user-attachments/assets/7454be8c-b98f-4237-858e-d04aa3dee0e3)
