### PR TITLE
fix: undefined mcp endpoint is copied when cancel endpoint selection

### DIFF
--- a/src/commands/copyMcpServerUrl.ts
+++ b/src/commands/copyMcpServerUrl.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { McpServerTreeItem } from '../explorer/McpServerTreeItem';
 import { localize } from '../localize';
 
-export async function copyMcpServerUrl(_context: IActionContext, node?: McpServerTreeItem): Promise<void> {
+export async function copyMcpServerUrl(context: IActionContext, node?: McpServerTreeItem): Promise<void> {
     try {
         if (!node) {
             return;
@@ -21,19 +21,21 @@ export async function copyMcpServerUrl(_context: IActionContext, node?: McpServe
         );
 
         // Show a quick pick to let user choose the endpoint type
-        const endpoints = ['SSE', 'Streamable HTTP'];
-        const endpointType = await vscode.window.showQuickPick(endpoints, {
-            placeHolder: 'Select endpoint type',
-            canPickMany: false
-        });
+        const endpointType = await context.ui.showQuickPick(
+            [
+                { label: 'SSE' },
+                { label: 'Streamable HTTP' }
+            ],
+            { placeHolder: 'Select endpoint type' }
+        );
 
         // Generate the URL based on selected endpoint type
         const baseUrl = `${apimService.gatewayUrl}/${node.mcpServerContract.properties.path}`;
-        const url = endpointType === 'SSE' ? `${baseUrl}/sse` : `${baseUrl}/mcp`;
+        const url = endpointType.label === 'SSE' ? `${baseUrl}/sse` : `${baseUrl}/mcp`;
 
         // Copy to clipboard
         await vscode.env.clipboard.writeText(url);
-        vscode.window.showInformationMessage(localize('mcpServerUrl.copied', `${endpointType} endpoint URL has been copied to clipboard.`));
+        vscode.window.showInformationMessage(localize('mcpServerUrl.copied', `${endpointType.label} endpoint URL has been copied to clipboard.`));
 
     } catch (error) {
         if (isUserCancelledError(error)) {


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2470937

The original implementation uses native VS Code api to show the quick pick, and didn't treat the user cancellation case as exception. Update the implementation to use UI utils from `@microsoft/vscode-azext-utils` to align with other command's implementation and handle the cancellation case correctly with code in line 41.