### PR TITLE
feat: create transformative and passthrough MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "@types/gulp": "^4.0.6",
                 "@types/jsonwebtoken": "^9.0.8",
                 "@types/mocha": "^10.0.0",
-                "@types/node": "^8.10.59",
+                "@types/node": "^18.0.0",
                 "@types/sinon": "^17.0.4",
                 "@types/swagger-parser": "^4.0.3",
                 "@types/vscode": "^1.50.1",
@@ -2494,9 +2494,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "8.10.62",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.62.tgz",
-            "integrity": "sha512-76fupxOYVxk36kb7O/6KtrAPZ9jnSK3+qisAX4tQMEuGNdlvl7ycwatlHqjoE6jHfVtXFM3pCrCixZOidc5cuw=="
+            "version": "18.19.112",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+            "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
@@ -11026,6 +11030,12 @@
                 "node": ">=18.17"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "license": "MIT"
+        },
         "node_modules/unicorn-magic": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -13989,9 +13999,12 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.10.62",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.62.tgz",
-            "integrity": "sha512-76fupxOYVxk36kb7O/6KtrAPZ9jnSK3+qisAX4tQMEuGNdlvl7ycwatlHqjoE6jHfVtXFM3pCrCixZOidc5cuw=="
+            "version": "18.19.112",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+            "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/normalize-package-data": {
             "version": "2.4.4",
@@ -20318,6 +20331,11 @@
             "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
             "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
             "dev": true
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "unicorn-magic": {
             "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -996,7 +996,7 @@
         "@types/gulp": "^4.0.6",
         "@types/jsonwebtoken": "^9.0.8",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^8.10.59",
+        "@types/node": "^18.0.0",
         "@types/sinon": "^17.0.4",
         "@types/swagger-parser": "^4.0.3",
         "@types/vscode": "^1.50.1",

--- a/package.json
+++ b/package.json
@@ -243,6 +243,11 @@
                 "category": "Azure API Management"
             },
             {
+                "command": "azureApiManagement.transformApiToMcpServer",
+                "title": "%azureApiManagement.transformApiToMcpServer%",
+                "category": "Azure API Management"
+            },
+            {
                 "command": "azureApiManagement.createService",
                 "title": "%azureApiManagement.createService%",
                 "category": "Azure API Management"
@@ -607,6 +612,10 @@
                 {
                     "command": "azureApiManagement.copyMcpServerUrl",
                     "when": "never"
+                },
+                {
+                    "command": "azureApiManagement.transformApiToMcpServer",
+                    "when": "never"
                 }
             ],
             "view/title": [
@@ -881,6 +890,11 @@
                     "command": "azureApiManagement.copyMcpServerUrl",
                     "when": "view == azureApiManagementExplorer && viewItem == azureApiManagementMcpServer",
                     "group": "1@2"
+                },
+                {
+                    "command": "azureApiManagement.transformApiToMcpServer",
+                    "when": "view == azureApiManagementExplorer && viewItem == azureApiManagementMcpServers",
+                    "group": "1@1"
                 }
             ],
             "copilot": [
@@ -947,7 +961,7 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run webpack-prod",
-        "build": "tsc -p ./ && gulp webpack-prod",
+        "build": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "package": "vsce package",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",

--- a/package.json
+++ b/package.json
@@ -248,6 +248,11 @@
                 "category": "Azure API Management"
             },
             {
+                "command": "azureApiManagement.passthroughMcpServer",
+                "title": "%azureApiManagement.passthroughMcpServer%",
+                "category": "Azure API Management"
+            },
+            {
                 "command": "azureApiManagement.createService",
                 "title": "%azureApiManagement.createService%",
                 "category": "Azure API Management"
@@ -616,6 +621,10 @@
                 {
                     "command": "azureApiManagement.transformApiToMcpServer",
                     "when": "never"
+                },
+                {
+                    "command": "azureApiManagement.passthroughMcpServer",
+                    "when": "never"
                 }
             ],
             "view/title": [
@@ -895,6 +904,11 @@
                     "command": "azureApiManagement.transformApiToMcpServer",
                     "when": "view == azureApiManagementExplorer && viewItem == azureApiManagementMcpServers",
                     "group": "1@1"
+                },
+                {
+                    "command": "azureApiManagement.passthroughMcpServer",
+                    "when": "view == azureApiManagementExplorer && viewItem == azureApiManagementMcpServers",
+                    "group": "1@2"
                 }
             ],
             "copilot": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,6 +52,7 @@
     "azureApiManagement.copyAuthorizationProviderRedirectUrl": "Copy RedirectUrl",
     "azureApiManagement.copyMcpServerUrl": "Copy Server URL",
     "azureApiManagement.transformApiToMcpServer": "Transform existing API to MCP server",
+    "azureApiManagement.passthroughMcpServer": "Passthrough an existing MCP server",
     "azureApiManagement.createAuthorization": "Create Credential",
     "azureApiManagement.authorizeAuthorization": "Login",
     "azureApiManagement.deleteAuthorization": "Delete Credential",

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,7 +52,7 @@
     "azureApiManagement.copyAuthorizationProviderRedirectUrl": "Copy RedirectUrl",
     "azureApiManagement.copyMcpServerUrl": "Copy Server URL",
     "azureApiManagement.transformApiToMcpServer": "Transform existing API to MCP server",
-    "azureApiManagement.passthroughMcpServer": "Passthrough an existing MCP server",
+    "azureApiManagement.passthroughMcpServer": "Proxy to an existing MCP server",
     "azureApiManagement.createAuthorization": "Create Credential",
     "azureApiManagement.authorizeAuthorization": "Login",
     "azureApiManagement.deleteAuthorization": "Delete Credential",

--- a/package.nls.json
+++ b/package.nls.json
@@ -51,6 +51,7 @@
     "azureApiManagement.deleteAuthorizationProvider": "Delete Credential Manager",
     "azureApiManagement.copyAuthorizationProviderRedirectUrl": "Copy RedirectUrl",
     "azureApiManagement.copyMcpServerUrl": "Copy Server URL",
+    "azureApiManagement.transformApiToMcpServer": "Transform existing API to MCP server",
     "azureApiManagement.createAuthorization": "Create Credential",
     "azureApiManagement.authorizeAuthorization": "Login",
     "azureApiManagement.deleteAuthorization": "Delete Credential",

--- a/src/azure/apim/ApimService.ts
+++ b/src/azure/apim/ApimService.ts
@@ -305,6 +305,23 @@ export class ApimService {
         // tslint:disable-next-line: no-unsafe-any
         return <IMcpServerApiContract[]>(result.parsedBody.value);
     }
+    
+    public async createMcpServer(mcpApiName: string, mcpServerPayload: any): Promise<IMcpServerApiContract> {
+        const client: ServiceClient = new ServiceClient(this.credentials, clientOptions);
+        const result: HttpOperationResponse = await client.sendRequest({
+            method: "PUT",
+            url: `${this.baseUrl}/apis/${mcpApiName}?api-version=2024-06-01-preview`,
+            body: mcpServerPayload
+        });
+        
+        if (result.status >= 400) {
+            const errorMessage = result.parsedBody?.error?.message || `Failed to create MCP server. Status: ${result.status}`;
+            throw new Error(errorMessage);
+        }
+        
+        // tslint:disable-next-line: no-unsafe-any
+        return <IMcpServerApiContract>(result.parsedBody);
+    }
 
     private genSiteUrl(endPointUrl: string, subscriptionId: string, resourceGroup: string, serviceName: string): string {
         return `${endPointUrl}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ApiManagement/service/${serviceName}`;

--- a/src/azure/apim/ApimService.ts
+++ b/src/azure/apim/ApimService.ts
@@ -305,12 +305,12 @@ export class ApimService {
         // tslint:disable-next-line: no-unsafe-any
         return <IMcpServerApiContract[]>(result.parsedBody.value);
     }
-    
+
     public async createMcpServer(mcpApiName: string, mcpServerPayload: any): Promise<IMcpServerApiContract> {
         const client: ServiceClient = new ServiceClient(this.credentials, clientOptions);
         const result: HttpOperationResponse = await client.sendRequest({
             method: "PUT",
-            url: `${this.baseUrl}/apis/${mcpApiName}?api-version=2024-06-01-preview`,
+            url: `${this.baseUrl}/apis/${mcpApiName}?api-version=2024-10-01-preview`,
             body: mcpServerPayload
         });
         
@@ -318,7 +318,6 @@ export class ApimService {
             const errorMessage = result.parsedBody?.error?.message || `Failed to create MCP server. Status: ${result.status}`;
             throw new Error(errorMessage);
         }
-        
         // tslint:disable-next-line: no-unsafe-any
         return <IMcpServerApiContract>(result.parsedBody);
     }

--- a/src/azure/apim/ApimService.ts
+++ b/src/azure/apim/ApimService.ts
@@ -315,8 +315,7 @@ export class ApimService {
         });
         
         if (result.status >= 400) {
-            const errorMessage = result.parsedBody?.error?.message || `Failed to create MCP server. Status: ${result.status}`;
-            throw new Error(errorMessage);
+            throw new Error(result.bodyAsText ?? `Failed to create MCP Server. Status code: ${result.status}`);
         }
         // tslint:disable-next-line: no-unsafe-any
         return <IMcpServerApiContract>(result.parsedBody);

--- a/src/commands/passthroughMcpServer.ts
+++ b/src/commands/passthroughMcpServer.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { BackendContract } from '@azure/arm-apimanagement';
+import { McpServersTreeItem } from '../explorer/McpServersTreeItem';
+import { ApimService } from '../azure/apim/ApimService';
+import { localize } from '../localize';
+
+export async function passthroughMcpServer(context: IActionContext, node?: McpServersTreeItem): Promise<void> {
+    try {
+        if (!node) {
+            return;
+        }
+
+        // Step 1: Ask user for MCP server name and display name
+        const mcpServerName = (await context.ui.showInputBox({
+            prompt: localize('enterMcpServerName', 'Enter the name for the MCP server'),
+            validateInput: (value: string): string | undefined => {
+                if (!value || value.trim().length === 0) {
+                    return localize('nameRequired', 'Name is required');
+                }
+                return undefined;
+            }
+        })).trim();
+
+        const displayName = (await context.ui.showInputBox({
+            prompt: localize('enterMcpServerDisplayName', 'Enter the display name for the MCP server'),
+            value: mcpServerName, // Default to the name
+            validateInput: (value: string): string | undefined => {
+                if (!value || value.trim().length === 0) {
+                    return localize('displayNameRequired', 'Display name is required');
+                }
+                return undefined;
+            }
+        })).trim();
+
+        // Step 2: Ask user for MCP server URL
+        const mcpServerUrl = (await context.ui.showInputBox({
+            prompt: localize('enterMcpServerUrl', 'Enter the URL of the MCP server'),
+            validateInput: (value: string): string | undefined => {
+                if (!value || value.trim().length === 0) {
+                    return localize('urlRequired', 'URL is required');
+                }
+                if (!value.trim().match(/^https?:\/\/.+/)) {
+                    return localize('invalidUrl', 'Please enter a valid URL starting with http:// or https://');
+                }
+                return undefined;
+            }
+        })).trim();
+
+        // Step 3: Ask user for SSE endpoint (relative URL)
+        const sseEndpoint = (await context.ui.showInputBox({
+            prompt: localize('enterSseEndpoint', 'Enter the SSE endpoint path (relative to the MCP server URL)'),
+            value: '/sse', // Default value
+            validateInput: (value: string): string | undefined => {
+                if (!value || value.trim().length === 0) {
+                    return localize('sseEndpointRequired', 'SSE endpoint is required');
+                }
+                return undefined;
+            }
+        })).trim();
+
+        // Step 4: Ask user for Messages endpoint (relative URL)
+        const messagesEndpoint = (await context.ui.showInputBox({
+            prompt: localize('enterMessagesEndpoint', 'Enter the Messages endpoint path (relative to the MCP server URL)'),
+            value: '/messages', // Default value
+            validateInput: (value: string): string | undefined => {
+                if (!value || value.trim().length === 0) {
+                    return localize('messagesEndpointRequired', 'Messages endpoint is required');
+                }
+                return undefined;
+            }
+        })).trim();
+
+        // Step 5: Create backend for the MCP server
+        const backendName = `${mcpServerName}-backend`;
+        
+        const backendContract: BackendContract = {
+            url: mcpServerUrl,
+            protocol: "http"
+        };
+
+        // Create backend using Azure Management SDK with progress
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: localize('creatingBackend', 'Creating APIM backend for MCP...'),
+            cancellable: false
+        }, async (_progress) => {
+            await node.root.client.backend.createOrUpdate(
+                node.root.resourceGroupName,
+                node.root.serviceName,
+                backendName,
+                backendContract
+            );
+        });
+
+        // Step 6: Create MCP server
+        const mcpServerPayload = {
+            properties: {
+                displayName: displayName,
+                protocols: ["http", "https"],
+                description: "This API is used to passthrough existing MCP server.",
+                subscriptionRequired: false,
+                path: mcpServerName,
+                type: "mcp",
+                backendId: backendName,
+                mcpProperties: {
+                    transportType: "sse",
+                    endpoints: {
+                        sse: {
+                            method: "GET",
+                            uriTemplate: sseEndpoint
+                        },
+                        messages: {
+                            method: "POST",
+                            uriTemplate: messagesEndpoint
+                        }
+                    }
+                }
+            }
+        };
+
+        // Step 6: Create MCP server using ApimService
+        const apimService = new ApimService(
+            node.root.credentials,
+            node.root.environment.resourceManagerEndpointUrl,
+            node.root.subscriptionId,
+            node.root.resourceGroupName,
+            node.root.serviceName
+        );
+
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: localize('creatingMcpServer', 'Creating MCP server...'),
+            cancellable: false
+        }, async (_progress) => {
+            await apimService.createMcpServer(mcpServerName.trim(), mcpServerPayload);
+        });
+
+        // Refresh the tree view to show the new MCP server
+        await node.refresh(context);
+
+        vscode.window.showInformationMessage(
+            localize('mcpServerPassthroughCreated', `Successfully created passthrough MCP server "${displayName}".`)
+        );
+
+    } catch (error) {
+        if (error.message && error.message.includes('UserCancelledError')) {
+            return;
+        }
+        vscode.window.showErrorMessage(`Failed to create passthrough MCP server: ${error.message}`);
+        throw error;
+    }
+}

--- a/src/commands/passthroughMcpServer.ts
+++ b/src/commands/passthroughMcpServer.ts
@@ -3,187 +3,272 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from '@microsoft/vscode-azext-utils';
-import * as vscode from 'vscode';
-import * as crypto from 'crypto';
-import { BackendContract } from '@azure/arm-apimanagement';
-import { McpServersTreeItem } from '../explorer/McpServersTreeItem';
-import { ApimService } from '../azure/apim/ApimService';
-import { localize } from '../localize';
+import {
+  IActionContext,
+  isUserCancelledError,
+} from "@microsoft/vscode-azext-utils";
+import * as vscode from "vscode";
+import * as crypto from "crypto";
+import { BackendContract } from "@azure/arm-apimanagement";
+import { McpServersTreeItem } from "../explorer/McpServersTreeItem";
+import { ApimService } from "../azure/apim/ApimService";
+import { localize } from "../localize";
 
-export async function passthroughMcpServer(context: IActionContext, node?: McpServersTreeItem): Promise<void> {
-    try {
-        if (!node) {
-            return;
-        }
+interface McpServerConfig {
+  mcpServerName: string;
+  displayName: string;
+  mcpServerUrl: string;
+  apiUrlSuffix: string;
+  protocolType: string;
+  sseEndpoint?: string;
+  messagesEndpoint?: string;
+}
 
-        // Step 1: Ask user for MCP server name and display name
-        const mcpServerName = (await context.ui.showInputBox({
-            prompt: localize('enterMcpServerName', 'Enter the name for the MCP server'),
-            validateInput: (value: string): string | undefined => {
-                if (!value || value.trim().length === 0) {
-                    return localize('nameRequired', 'Name is required');
-                }
-                return undefined;
-            }
-        })).trim();
-
-        const displayName = (await context.ui.showInputBox({
-            prompt: localize('enterMcpServerDisplayName', 'Enter the display name for the MCP server'),
-            value: mcpServerName, // Default to the name
-            validateInput: (value: string): string | undefined => {
-                if (!value || value.trim().length === 0) {
-                    return localize('displayNameRequired', 'Display name is required');
-                }
-                return undefined;
-            }
-        })).trim();
-
-        // Step 2: Ask user to select transport protocol
-        const protocolChoice = await context.ui.showQuickPick([
-            { label: 'SSE', description: 'Server-Sent Events' },
-            { label: 'Streamable HTTP', description: 'Streamable HTTP protocol' }
-        ], {
-            placeHolder: localize('selectProtocol', 'Select the transport protocol for the MCP server')
-        });
-
-        const transportType = protocolChoice.label === 'SSE' ? 'sse' : 'streamable-http';
-
-        // Step 3: Ask user for MCP server URL
-        const mcpServerUrl = (await context.ui.showInputBox({
-            prompt: localize('enterMcpServerUrl', 'Enter the URL of the MCP server'),
-            validateInput: (value: string): string | undefined => {
-                if (!value || value.trim().length === 0) {
-                    return localize('urlRequired', 'URL is required');
-                }
-                if (!value.trim().match(/^https?:\/\/.+/)) {
-                    return localize('invalidUrl', 'Please enter a valid URL starting with http:// or https://');
-                }
-                return undefined;
-            }
-        })).trim();
-
-        // Step 4: Ask user for APIM API URL suffix
-        const apiUrlSuffix = (await context.ui.showInputBox({
-            prompt: localize('enterApiUrlSuffix', 'Enter the APIM API URL suffix'),
-            value: mcpServerName, // Default to the server name
-            validateInput: (value: string): string | undefined => {
-                if (!value || value.trim().length === 0) {
-                    return localize('apiUrlSuffixRequired', 'API URL suffix is required');
-                }
-                return undefined;
-            }
-        })).trim();
-
-        // Step 5: For SSE protocol, ask for SSE and Messages endpoints
-        let sseEndpoint = '';
-        let messagesEndpoint = '';
-        
-        if (transportType === 'sse') {
-            sseEndpoint = (await context.ui.showInputBox({
-                prompt: localize('enterSseEndpoint', 'Enter the SSE endpoint path (relative to the MCP server URL)'),
-                value: '/sse', // Default value
-                validateInput: (value: string): string | undefined => {
-                    if (!value || value.trim().length === 0) {
-                        return localize('sseEndpointRequired', 'SSE endpoint is required');
-                    }
-                    return undefined;
-                }
-            })).trim();
-
-            messagesEndpoint = (await context.ui.showInputBox({
-                prompt: localize('enterMessagesEndpoint', 'Enter the Messages endpoint path (relative to the MCP server URL)'),
-                value: '/messages', // Default value
-                validateInput: (value: string): string | undefined => {
-                    if (!value || value.trim().length === 0) {
-                        return localize('messagesEndpointRequired', 'Messages endpoint is required');
-                    }
-                    return undefined;
-                }
-            })).trim();
-        }
-
-        // Step 6: Create backend for the MCP server with random GUID name
-        const backendName = crypto.randomUUID();
-        
-        const backendContract: BackendContract = {
-            url: mcpServerUrl,
-            protocol: "http"
-        };
-
-        // Create backend using Azure Management SDK with progress
-        await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: localize('creatingBackend', 'Creating APIM backend for MCP...'),
-            cancellable: false
-        }, async (_progress) => {
-            await node.root.client.backend.createOrUpdate(
-                node.root.resourceGroupName,
-                node.root.serviceName,
-                backendName,
-                backendContract
-            );
-        });
-
-        // Step 7: Create MCP server payload based on transport type
-        let mcpServerPayload: any = {
-            properties: {
-                displayName: displayName,
-                protocols: ["http", "https"],
-                description: "This API is used to passthrough existing MCP server.",
-                subscriptionRequired: false,
-                path: apiUrlSuffix,
-                type: "mcp",
-                backendId: backendName,
-                mcpProperties: {
-                    transportType: transportType
-                }
-            }
-        };
-
-        // Add endpoints for SSE protocol
-        if (transportType === 'sse') {
-            mcpServerPayload.properties.mcpProperties.endpoints = {
-                sse: {
-                    method: "GET",
-                    uriTemplate: sseEndpoint
-                },
-                messages: {
-                    method: "POST",
-                    uriTemplate: messagesEndpoint
-                }
-            };
-        }
-
-        // Step 8: Create MCP server using ApimService
-        const apimService = new ApimService(
-            node.root.credentials,
-            node.root.environment.resourceManagerEndpointUrl,
-            node.root.subscriptionId,
-            node.root.resourceGroupName,
-            node.root.serviceName
-        );
-
-        await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: localize('creatingMcpServer', 'Creating MCP server...'),
-            cancellable: false
-        }, async (_progress) => {
-            await apimService.createMcpServer(mcpServerName.trim(), mcpServerPayload);
-        });
-
-        // Refresh the tree view to show the new MCP server
-        await node.refresh(context);
-
-        vscode.window.showInformationMessage(
-            localize('mcpServerPassthroughCreated', `Successfully proxied MCP server "${displayName}" with ${transportType.toUpperCase()} protocol.`)
-        );
-
-    } catch (error) {
-        if (error.message && error.message.includes('UserCancelledError')) {
-            return;
-        }
-        vscode.window.showErrorMessage(`Failed to proxy MCP server: ${error.message}`);
-        throw error;
+export async function passthroughMcpServer(
+  context: IActionContext,
+  node?: McpServersTreeItem
+): Promise<void> {
+  try {
+    if (!node) {
+      return;
     }
+
+    const mcpServerName = (
+      await context.ui.showInputBox({
+        prompt: localize(
+          "enterMcpServerName",
+          "Enter the name for the MCP server"
+        ),
+        validateInput: (value: string): string | undefined => {
+          if (!value || value.trim().length === 0) {
+            return localize("nameRequired", "Name is required");
+          }
+          return undefined;
+        },
+      })
+    ).trim();
+
+    const displayName = (
+      await context.ui.showInputBox({
+        prompt: localize(
+          "enterMcpServerDisplayName",
+          "Enter the display name for the MCP server"
+        ),
+        value: mcpServerName, // Default to the name
+        validateInput: (value: string): string | undefined => {
+          if (!value || value.trim().length === 0) {
+            return localize("displayNameRequired", "Display name is required");
+          }
+          return undefined;
+        },
+      })
+    ).trim();
+
+    const protocolChoice = await context.ui.showQuickPick(
+      [
+        { label: "SSE", description: "Server-Sent Events" },
+        { label: "Streamable HTTP", description: "Streamable HTTP protocol" },
+      ],
+      {
+        placeHolder: localize(
+          "selectProtocol",
+          "Select the transport protocol for the MCP server"
+        ),
+      }
+    );
+
+    const mcpServerUrl = (
+      await context.ui.showInputBox({
+        prompt: localize(
+          "enterMcpServerUrl",
+          "Enter the URL of the MCP server"
+        ),
+        validateInput: (value: string): string | undefined => {
+          if (!value || value.trim().length === 0) {
+            return localize("urlRequired", "URL is required");
+          }
+          if (!value.trim().match(/^https?:\/\/.+/)) {
+            return localize(
+              "invalidUrl",
+              "Please enter a valid URL starting with http:// or https://"
+            );
+          }
+          return undefined;
+        },
+      })
+    ).trim();
+
+    const apiUrlSuffix = (
+      await context.ui.showInputBox({
+        prompt: localize("enterApiUrlSuffix", "Enter the APIM API URL suffix"),
+        value: mcpServerName, // Default to the server name
+        validateInput: (value: string): string | undefined => {
+          if (!value || value.trim().length === 0) {
+            return localize(
+              "apiUrlSuffixRequired",
+              "API URL suffix is required"
+            );
+          }
+          return undefined;
+        },
+      })
+    ).trim();
+
+    let sseEndpoint = "";
+    let messagesEndpoint = "";
+
+    // For SSE protocol, ask for SSE and Messages endpoints
+    if (protocolChoice.label === "SSE") {
+      sseEndpoint = (
+        await context.ui.showInputBox({
+          prompt: localize(
+            "enterSseEndpoint",
+            "Enter the SSE endpoint path (relative to the MCP server URL)"
+          ),
+          value: "/sse", // Default value
+          validateInput: (value: string): string | undefined => {
+            if (!value || value.trim().length === 0) {
+              return localize(
+                "sseEndpointRequired",
+                "SSE endpoint is required"
+              );
+            }
+            return undefined;
+          },
+        })
+      ).trim();
+
+      messagesEndpoint = (
+        await context.ui.showInputBox({
+          prompt: localize(
+            "enterMessagesEndpoint",
+            "Enter the Messages endpoint path (relative to the MCP server URL)"
+          ),
+          value: "/messages", // Default value
+          validateInput: (value: string): string | undefined => {
+            if (!value || value.trim().length === 0) {
+              return localize(
+                "messagesEndpointRequired",
+                "Messages endpoint is required"
+              );
+            }
+            return undefined;
+          },
+        })
+      ).trim();
+    }
+
+    // Create MCP server resources
+    const config: McpServerConfig = {
+      mcpServerName,
+      displayName,
+      mcpServerUrl,
+      apiUrlSuffix,
+      protocolType: protocolChoice.label,
+      sseEndpoint: protocolChoice.label === "SSE" ? sseEndpoint : undefined,
+      messagesEndpoint:
+        protocolChoice.label === "SSE" ? messagesEndpoint : undefined,
+    };
+
+    await createMcpServer(node, config);
+
+    await node.refresh(context);
+
+    vscode.window.showInformationMessage(
+      localize(
+        "mcpServerPassthroughCreated",
+        `Successfully proxied MCP server "${displayName}" with ${protocolChoice.label} protocol.`
+      )
+    );
+  } catch (error) {
+    if (isUserCancelledError(error)) {
+      throw error;
+    }
+
+    // azext-utils only show the outer error, which does not include error details.
+    // Compose the error message as non JSON format to skip azext-utils' error handling.
+    const message = `Failed to proxy MCP server: ${error.message}`;
+    throw new Error(message);
+  }
+}
+
+async function createMcpServer(
+  node: McpServersTreeItem,
+  config: McpServerConfig
+): Promise<void> {
+  const backendName = crypto.randomUUID(); // Use guid as name to avoid conflict
+  const backendContract: BackendContract = {
+    url: config.mcpServerUrl,
+    protocol: "http",
+  };
+
+  // Create the backend
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: localize("creatingBackend", "Creating APIM backend for MCP..."),
+      cancellable: false,
+    },
+    async (_progress) => {
+      await node.root.client.backend.createOrUpdate(
+        node.root.resourceGroupName,
+        node.root.serviceName,
+        backendName,
+        backendContract
+      );
+    }
+  );
+
+  // Create the MCP server payload
+  let mcpServerPayload: any = {
+    properties: {
+      displayName: config.displayName,
+      protocols: ["http", "https"],
+      description: "This API is used to passthrough existing MCP server.",
+      subscriptionRequired: false,
+      path: config.apiUrlSuffix,
+      type: "mcp",
+      backendId: backendName,
+    },
+  };
+
+  // Add MCP properties only for SSE protocol
+  if (config.protocolType === "SSE") {
+    mcpServerPayload.properties.mcpProperties = {
+      transportType: "sse",
+      endpoints: {
+        sse: {
+          method: "GET",
+          uriTemplate: config.sseEndpoint,
+        },
+        messages: {
+          method: "POST",
+          uriTemplate: config.messagesEndpoint,
+        },
+      },
+    };
+  }
+
+  // Create the MCP server
+  const apimService = new ApimService(
+    node.root.credentials,
+    node.root.environment.resourceManagerEndpointUrl,
+    node.root.subscriptionId,
+    node.root.resourceGroupName,
+    node.root.serviceName
+  );
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: localize("creatingMcpServer", "Creating MCP server..."),
+      cancellable: false,
+    },
+    async (_progress) => {
+      await apimService.createMcpServer(
+        config.mcpServerName.trim(),
+        mcpServerPayload
+      );
+    }
+  );
 }

--- a/src/commands/transformApiToMcpServer.ts
+++ b/src/commands/transformApiToMcpServer.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { uiUtils } from '@microsoft/vscode-azext-azureutils';
+import { ApiContract, OperationContract } from '@azure/arm-apimanagement';
+import * as vscode from 'vscode';
+import { McpServersTreeItem } from '../explorer/McpServersTreeItem';
+import { ApimService } from '../azure/apim/ApimService';
+import { localize } from '../localize';
+import { apiUtil } from '../utils/apiUtil';
+import { IMcpToolContract } from '../azure/apim/contracts';
+
+interface IApiQuickPickItem {
+    label: string;
+    api: ApiContract;
+}
+
+interface IOperationQuickPickItem {
+    label: string;
+    description: string;
+    operation: OperationContract;
+}
+
+export async function transformApiToMcpServer(context: IActionContext, node?: McpServersTreeItem): Promise<void> {
+    try {
+        if (!node) {
+            return;
+        }
+
+        // Step 1: Show list of APIs and let user select one
+        const selectedApi = await selectApi(context, node);
+        if (!selectedApi) {
+            return;
+        }
+
+        // Step 2: Show operations of the selected API and let user select one or more
+        const selectedOperations = await selectOperations(context, node, selectedApi);
+        if (!selectedOperations || selectedOperations.length === 0) {
+            return;
+        }
+
+        // Step 3: Create MCP server with selected operations
+        await createMcpServer(context, node, selectedApi, selectedOperations);
+
+        // Refresh the tree view to show the new MCP server
+        await node.refresh(context);
+
+        vscode.window.showInformationMessage(
+            localize('mcpServerCreated', `Successfully created MCP server from API "${selectedApi.displayName}".`)
+        );
+
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to transform API to MCP server: ${error.message}`);
+        throw error;
+    }
+}
+
+async function selectApi(context: IActionContext, node: McpServersTreeItem): Promise<ApiContract | undefined> {
+    // Get all APIs from the service
+    const apiCollection: ApiContract[] = await uiUtils.listAllIterator(
+        node.root.client.api.listByService(node.root.resourceGroupName, node.root.serviceName, { expandApiVersionSet: true })
+    );
+
+    // Filter out revisions and prepare for quick pick
+    const apis = apiCollection.filter(api => apiUtil.isNotApiRevision(api));
+    
+    if (apis.length === 0) {
+        vscode.window.showInformationMessage(localize('noApisFound', 'No APIs found in the current API Management service.'));
+        return undefined;
+    }
+
+    const apiItems: IApiQuickPickItem[] = apis.map(api => ({
+        label: api.displayName || api.name!,
+        api: api
+    }));
+
+    const selectedItem = await context.ui.showQuickPick(
+        apiItems,
+        { 
+            canPickMany: false, 
+            placeHolder: localize('selectApi', 'Select an API to transform to MCP server')
+        }
+    );
+
+    return selectedItem.api;
+}
+
+async function selectOperations(context: IActionContext, node: McpServersTreeItem, api: ApiContract): Promise<OperationContract[] | undefined> {
+    // Get all operations for the selected API
+    const operations: OperationContract[] = await uiUtils.listAllIterator(
+        node.root.client.apiOperation.listByApi(node.root.resourceGroupName, node.root.serviceName, api.name!)
+    );
+
+    if (operations.length === 0) {
+        vscode.window.showInformationMessage(
+            localize('noOperationsFound', `No operations found in API "${api.displayName}".`)
+        );
+        return undefined;
+    }
+    
+    const operationItems: IOperationQuickPickItem[] = operations.map(operation => ({
+        label: operation.displayName || operation.name!,
+        description: operation.description ? `${operation.method?.toUpperCase()} - ${operation.description}` : operation.method?.toUpperCase() || '',
+        operation: operation
+    }));
+
+    const selectedItems = await context.ui.showQuickPick(
+        operationItems,
+        { 
+            canPickMany: true, 
+            placeHolder: localize('selectOperations', 'Select one or more operations to include in the MCP server')
+        }
+    );
+
+    return selectedItems.map(item => item.operation);
+}
+
+async function createMcpServer(
+    _context: IActionContext, 
+    node: McpServersTreeItem, 
+    api: ApiContract, 
+    operations: OperationContract[]
+): Promise<void> {
+    const apimService = new ApimService(
+        node.root.credentials,
+        node.root.environment.resourceManagerEndpointUrl,
+        node.root.subscriptionId,
+        node.root.resourceGroupName,
+        node.root.serviceName
+    );
+
+    // Compose MCP API details
+    const originalApiName = api.name!;
+    const mcpApiName = `${originalApiName}-mcp`;
+    const mcpApiDisplayName = `${api.displayName || originalApiName} MCP`;
+    const mcpApiPath = `${api.path!}-mcp`;
+
+    // Create MCP tools from selected operations
+    const mcpTools: IMcpToolContract[] = operations.map(operation => ({
+        name: operation.name!,
+        description: operation.description || '',
+        operationId: `/subscriptions/${node.root.subscriptionId}/resourceGroups/${node.root.resourceGroupName}/providers/Microsoft.ApiManagement/service/${node.root.serviceName}/apis/${originalApiName}/operations/${operation.name}`
+    }));
+
+    // Prepare the request body for creating MCP server
+    const mcpServerPayload = {
+        id: `/subscriptions/${node.root.subscriptionId}/resourceGroups/${node.root.resourceGroupName}/providers/Microsoft.ApiManagement/service/${node.root.serviceName}/apis/${mcpApiName}`,
+        name: mcpApiName,
+        properties: {
+            type: "mcp",
+            displayName: mcpApiDisplayName,
+            subscriptionRequired: false,
+            path: mcpApiPath,
+            protocols: ["http", "https"],
+            mcpTools: mcpTools
+        }
+    };
+
+    // Create the MCP server using the API Management REST API
+    await apimService.createMcpServer(mcpApiName, mcpServerPayload);
+}

--- a/src/commands/transformApiToMcpServer.ts
+++ b/src/commands/transformApiToMcpServer.ts
@@ -3,162 +3,222 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { uiUtils } from '@microsoft/vscode-azext-azureutils';
-import { ApiContract, OperationContract } from '@azure/arm-apimanagement';
-import * as vscode from 'vscode';
-import { McpServersTreeItem } from '../explorer/McpServersTreeItem';
-import { ApimService } from '../azure/apim/ApimService';
-import { localize } from '../localize';
-import { apiUtil } from '../utils/apiUtil';
-import { IMcpToolContract } from '../azure/apim/contracts';
+import {
+  IActionContext,
+  isUserCancelledError,
+} from "@microsoft/vscode-azext-utils";
+import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { ApiContract, OperationContract } from "@azure/arm-apimanagement";
+import * as vscode from "vscode";
+import { McpServersTreeItem } from "../explorer/McpServersTreeItem";
+import { ApimService } from "../azure/apim/ApimService";
+import { localize } from "../localize";
+import { IMcpToolContract } from "../azure/apim/contracts";
 
 interface IApiQuickPickItem {
-    label: string;
-    api: ApiContract;
+  label: string;
+  api: ApiContract;
 }
 
 interface IOperationQuickPickItem {
-    label: string;
-    description: string;
-    operation: OperationContract;
+  label: string;
+  description: string;
+  operation: OperationContract;
 }
 
-export async function transformApiToMcpServer(context: IActionContext, node?: McpServersTreeItem): Promise<void> {
-    try {
-        if (!node) {
-            return;
-        }
-
-        // Step 1: Show list of APIs and let user select one
-        const selectedApi = await selectApi(context, node);
-        if (!selectedApi) {
-            return;
-        }
-
-        // Step 2: Show operations of the selected API and let user select one or more
-        const selectedOperations = await selectOperations(context, node, selectedApi);
-        if (!selectedOperations || selectedOperations.length === 0) {
-            return;
-        }
-
-        // Step 3: Create MCP server with selected operations
-        await createMcpServer(context, node, selectedApi, selectedOperations);
-
-        // Refresh the tree view to show the new MCP server
-        await node.refresh(context);
-
-        vscode.window.showInformationMessage(
-            localize('mcpServerCreated', `Successfully created MCP server from API "${selectedApi.displayName}".`)
-        );
-
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to transform API to MCP server: ${error.message}`);
-        throw error;
+export async function transformApiToMcpServer(
+  context: IActionContext,
+  node?: McpServersTreeItem
+): Promise<void> {
+  try {
+    if (!node) {
+      return;
     }
+
+    const selectedApi = await selectApi(context, node);
+    if (!selectedApi) {
+      return;
+    }
+
+    const selectedOperations = await selectOperations(
+      context,
+      node,
+      selectedApi
+    );
+    if (!selectedOperations || selectedOperations.length === 0) {
+      return;
+    }
+
+    const defaultApiUrlSuffix = `${selectedApi.path || selectedApi.name}-mcp`;
+    const apiUrlSuffix = (
+      await context.ui.showInputBox({
+        prompt: localize(
+          "enterApiUrlSuffix",
+          "Enter the API URL suffix for the MCP server"
+        ),
+        value: defaultApiUrlSuffix,
+        validateInput: (value: string) => {
+          if (!value || value.trim().length === 0) {
+            return localize(
+              "apiUrlSuffixRequired",
+              "API URL suffix is required"
+            );
+          }
+          return undefined;
+        },
+      })
+    ).trim();
+
+    await createMcpServer(node, selectedApi, selectedOperations, apiUrlSuffix);
+
+    await node.refresh(context);
+
+    vscode.window.showInformationMessage(
+      localize(
+        "mcpServerCreated",
+        `Successfully created MCP server from API "${selectedApi.displayName}".`
+      )
+    );
+  } catch (error) {
+    if (isUserCancelledError(error)) {
+      throw error;
+    }
+
+    // azext-utils only show the outer error, which does not include error details.
+    // Compose the error message as non JSON format to skip azext-utils' error handling.
+    const message = `Failed to transform API to MCP server: ${error.message}`;
+    throw new Error(message);
+  }
 }
 
-async function selectApi(context: IActionContext, node: McpServersTreeItem): Promise<ApiContract | undefined> {
-    // Get all APIs from the service
-    const apiCollection: ApiContract[] = await uiUtils.listAllIterator(
-        node.root.client.api.listByService(node.root.resourceGroupName, node.root.serviceName, { expandApiVersionSet: true })
+async function selectApi(
+  context: IActionContext,
+  node: McpServersTreeItem
+): Promise<ApiContract | undefined> {
+  const apis: ApiContract[] = await uiUtils.listAllIterator(
+    node.root.client.api.listByService(
+      node.root.resourceGroupName,
+      node.root.serviceName,
+      { expandApiVersionSet: true }
+    )
+  );
+
+  if (apis.length === 0) {
+    vscode.window.showInformationMessage(
+      localize(
+        "noApisFound",
+        "No APIs found in the current API Management service."
+      )
     );
+    return undefined;
+  }
 
-    // Filter out revisions and prepare for quick pick
-    const apis = apiCollection.filter(api => apiUtil.isNotApiRevision(api));
-    
-    if (apis.length === 0) {
-        vscode.window.showInformationMessage(localize('noApisFound', 'No APIs found in the current API Management service.'));
-        return undefined;
-    }
+  const apiItems: IApiQuickPickItem[] = apis.map((api) => ({
+    label: api.displayName || api.name!,
+    api: api,
+  }));
 
-    const apiItems: IApiQuickPickItem[] = apis.map(api => ({
-        label: api.displayName || api.name!,
-        api: api
-    }));
+  const selectedItem = await context.ui.showQuickPick(apiItems, {
+    canPickMany: false,
+    placeHolder: localize(
+      "selectApi",
+      "Select an API to transform to MCP server"
+    ),
+  });
 
-    const selectedItem = await context.ui.showQuickPick(
-        apiItems,
-        { 
-            canPickMany: false, 
-            placeHolder: localize('selectApi', 'Select an API to transform to MCP server')
-        }
-    );
-
-    return selectedItem.api;
+  return selectedItem.api;
 }
 
-async function selectOperations(context: IActionContext, node: McpServersTreeItem, api: ApiContract): Promise<OperationContract[] | undefined> {
-    // Get all operations for the selected API
-    const operations: OperationContract[] = await uiUtils.listAllIterator(
-        node.root.client.apiOperation.listByApi(node.root.resourceGroupName, node.root.serviceName, api.name!)
+async function selectOperations(
+  context: IActionContext,
+  node: McpServersTreeItem,
+  api: ApiContract
+): Promise<OperationContract[] | undefined> {
+  const operations: OperationContract[] = await uiUtils.listAllIterator(
+    node.root.client.apiOperation.listByApi(
+      node.root.resourceGroupName,
+      node.root.serviceName,
+      api.name!
+    )
+  );
+
+  if (operations.length === 0) {
+    vscode.window.showInformationMessage(
+      localize(
+        "noOperationsFound",
+        `No operations found in API "${api.displayName}".`
+      )
     );
+    return undefined;
+  }
 
-    if (operations.length === 0) {
-        vscode.window.showInformationMessage(
-            localize('noOperationsFound', `No operations found in API "${api.displayName}".`)
-        );
-        return undefined;
-    }
-    
-    const operationItems: IOperationQuickPickItem[] = operations.map(operation => ({
-        label: operation.displayName || operation.name!,
-        description: operation.description ? `${operation.method?.toUpperCase()} - ${operation.description}` : operation.method?.toUpperCase() || '',
-        operation: operation
-    }));
+  const operationItems: IOperationQuickPickItem[] = operations.map(
+    (operation) => ({
+      label: operation.displayName!, // Display name is required when create operation, so will not be undefined
+      description: operation.description
+        ? `${operation.method!.toUpperCase()} - ${operation.description}`
+        : operation.method!.toUpperCase(), // Method is required when create operation, so will not be undefined
+      operation: operation,
+    })
+  );
 
-    const selectedItems = await context.ui.showQuickPick(
-        operationItems,
-        { 
-            canPickMany: true, 
-            placeHolder: localize('selectOperations', 'Select one or more operations to include in the MCP server')
-        }
-    );
+  const selectedItems = await context.ui.showQuickPick(operationItems, {
+    canPickMany: true,
+    placeHolder: localize(
+      "selectOperations",
+      "Select one or more operations to include in the MCP server"
+    ),
+  });
 
-    return selectedItems.map(item => item.operation);
+  return selectedItems.map((item) => item.operation);
 }
 
 async function createMcpServer(
-    _context: IActionContext, 
-    node: McpServersTreeItem, 
-    api: ApiContract, 
-    operations: OperationContract[]
+  node: McpServersTreeItem,
+  api: ApiContract,
+  operations: OperationContract[],
+  apiUrlSuffix: string
 ): Promise<void> {
-    const apimService = new ApimService(
-        node.root.credentials,
-        node.root.environment.resourceManagerEndpointUrl,
-        node.root.subscriptionId,
-        node.root.resourceGroupName,
-        node.root.serviceName
-    );
+  const apimService = new ApimService(
+    node.root.credentials,
+    node.root.environment.resourceManagerEndpointUrl,
+    node.root.subscriptionId,
+    node.root.resourceGroupName,
+    node.root.serviceName
+  );
 
-    // Compose MCP API details
-    const originalApiName = api.name!;
-    const mcpApiName = `${originalApiName}-mcp`;
-    const mcpApiDisplayName = `${api.displayName || originalApiName} MCP`;
-    const mcpApiPath = `${api.path!}-mcp`;
+  const originalApiName = api.name!;
+  const mcpApiName = `${originalApiName}-mcp`;
+  const mcpApiDisplayName = `${api.displayName || originalApiName} MCP`;
+  const mcpApiPath = apiUrlSuffix;
 
-    // Create MCP tools from selected operations
-    const mcpTools: IMcpToolContract[] = operations.map(operation => ({
-        name: operation.name!,
-        description: operation.description || '',
-        operationId: `/subscriptions/${node.root.subscriptionId}/resourceGroups/${node.root.resourceGroupName}/providers/Microsoft.ApiManagement/service/${node.root.serviceName}/apis/${originalApiName}/operations/${operation.name}`
-    }));
+  const mcpTools: IMcpToolContract[] = operations.map((operation) => ({
+    name: operation.name!,
+    description: operation.description || "",
+    operationId: `/subscriptions/${node.root.subscriptionId}/resourceGroups/${node.root.resourceGroupName}/providers/Microsoft.ApiManagement/service/${node.root.serviceName}/apis/${originalApiName}/operations/${operation.name}`,
+  }));
 
-    // Prepare the request body for creating MCP server
-    const mcpServerPayload = {
-        id: `/subscriptions/${node.root.subscriptionId}/resourceGroups/${node.root.resourceGroupName}/providers/Microsoft.ApiManagement/service/${node.root.serviceName}/apis/${mcpApiName}`,
-        name: mcpApiName,
-        properties: {
-            type: "mcp",
-            displayName: mcpApiDisplayName,
-            subscriptionRequired: false,
-            path: mcpApiPath,
-            protocols: ["http", "https"],
-            mcpTools: mcpTools
-        }
-    };
+  const mcpServerPayload = {
+    id: `/subscriptions/${node.root.subscriptionId}/resourceGroups/${node.root.resourceGroupName}/providers/Microsoft.ApiManagement/service/${node.root.serviceName}/apis/${mcpApiName}`,
+    name: mcpApiName,
+    properties: {
+      type: "mcp",
+      displayName: mcpApiDisplayName,
+      subscriptionRequired: false,
+      path: mcpApiPath,
+      protocols: ["http", "https"],
+      mcpTools: mcpTools,
+    },
+  };
 
-    // Create the MCP server using the API Management REST API
-    await apimService.createMcpServer(mcpApiName, mcpServerPayload);
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: localize("creatingMcpServer", "Creating MCP server..."),
+      cancellable: false,
+    },
+    async (_progress) => {
+      await apimService.createMcpServer(mcpApiName, mcpServerPayload);
+    }
+  );
 }

--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -55,7 +55,13 @@ class ApimPolicyDebugAdapterDescriptorFactory implements vscode.DebugAdapterDesc
         }
 
         // make VS Code connect to debug server
-        return new vscode.DebugAdapterServer(this.server.address().port);
+        const address = this.server.address();
+        if (address && typeof address === 'object') {
+            return new vscode.DebugAdapterServer(address.port);
+        }
+        // Newer nodejs version may return non-object address for certain server type
+        // This won't happen for current implementation, but we need to handle this case to avoid build failure
+        throw new Error('Failed to get server port');
     }
 
     public dispose() {

--- a/src/explorer/McpServerTreeItem.ts
+++ b/src/explorer/McpServerTreeItem.ts
@@ -52,7 +52,16 @@ export class McpServerTreeItem extends AzExtParentTreeItem {
     }
 
     public async loadMoreChildrenImpl(): Promise<any[]> {
-        return [this.toolsTreeItem, this.policyTreeItem];
+        const children: any[] = [];
+        
+        // Only include tools tree item if there are actually tools
+        const tools = this.mcpServerContract.properties.mcpTools || [];
+        if (tools.length > 0) {
+            children.push(this.toolsTreeItem);
+        }
+        
+        children.push(this.policyTreeItem);
+        return children;
     }
 
     private createRoot(subRoot: IServiceTreeRoot, apiName: string): IApiTreeRoot {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,6 +86,7 @@ import { AvailablePoliciesTool } from './tools/availablePoliciesTool';
 import { showReleaseNotes } from './utils/extensionUtil';
 import { copyMcpServerUrl } from './commands/copyMcpServerUrl';
 import { transformApiToMcpServer } from './commands/transformApiToMcpServer';
+import { passthroughMcpServer } from './commands/passthroughMcpServer';
 import { LearnMoreMcpTreeItem, McpServersTreeItem } from './explorer/McpServersTreeItem';
 
 // this method is called when your extension is activated
@@ -212,6 +213,7 @@ function registerCommands(tree: AzExtTreeDataProvider): void {
     registerCommand('azureApiManagement.draftPolicy', async (context: IActionContext) => await draftPolicy(context));
     registerCommand('azureApiManagement.copyMcpServerUrl', copyMcpServerUrl);
     registerCommand('azureApiManagement.transformApiToMcpServer', async (context: IActionContext, node?: McpServersTreeItem) => { await transformApiToMcpServer(context, node); });
+    registerCommand('azureApiManagement.passthroughMcpServer', async (context: IActionContext, node?: McpServersTreeItem) => { await passthroughMcpServer(context, node); });
     registerCommand('azureApiManagement.openMcpLearnMore', async (_context: IActionContext, node: LearnMoreMcpTreeItem) => {
         if (node) {
             await node.openPage();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,8 @@ import { draftPolicy } from './commands/draftPolicy';
 import { AvailablePoliciesTool } from './tools/availablePoliciesTool';
 import { showReleaseNotes } from './utils/extensionUtil';
 import { copyMcpServerUrl } from './commands/copyMcpServerUrl';
-import { LearnMoreMcpTreeItem } from './explorer/McpServersTreeItem';
+import { transformApiToMcpServer } from './commands/transformApiToMcpServer';
+import { LearnMoreMcpTreeItem, McpServersTreeItem } from './explorer/McpServersTreeItem';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -210,6 +211,7 @@ function registerCommands(tree: AzExtTreeDataProvider): void {
     registerCommand('azureApiManagement.explainPolicy', async (context: IActionContext) => await explainPolicy(context));
     registerCommand('azureApiManagement.draftPolicy', async (context: IActionContext) => await draftPolicy(context));
     registerCommand('azureApiManagement.copyMcpServerUrl', copyMcpServerUrl);
+    registerCommand('azureApiManagement.transformApiToMcpServer', async (context: IActionContext, node?: McpServersTreeItem) => { await transformApiToMcpServer(context, node); });
     registerCommand('azureApiManagement.openMcpLearnMore', async (_context: IActionContext, node: LearnMoreMcpTreeItem) => {
         if (node) {
             await node.openPage();

--- a/test/passthroughMcpServer.test.ts
+++ b/test/passthroughMcpServer.test.ts
@@ -1,0 +1,458 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import { BackendContract } from '@azure/arm-apimanagement';
+import { passthroughMcpServer } from '../src/commands/passthroughMcpServer';
+import { McpServersTreeItem } from '../src/explorer/McpServersTreeItem';
+import { ApimService } from '../src/azure/apim/ApimService';
+import { IServiceTreeRoot } from '../src/explorer/IServiceTreeRoot';
+
+describe('passthroughMcpServer', () => {
+    let sandbox: sinon.SinonSandbox;
+    let mockContext: IActionContext;
+    let mockNode: McpServersTreeItem;
+    let mockRoot: IServiceTreeRoot;
+    let mockApimService: sinon.SinonStubbedInstance<ApimService>;
+    let mockVscodeWindow: sinon.SinonStub;
+    let mockVscodeWindowProgress: sinon.SinonStub;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        // Mock VSCode window methods
+        mockVscodeWindow = sandbox.stub(vscode.window, 'showInformationMessage');
+        mockVscodeWindowProgress = sandbox.stub(vscode.window, 'withProgress');
+
+        // Mock ActionContext
+        mockContext = {
+            ui: {
+                showQuickPick: sandbox.stub(),
+                showInputBox: sandbox.stub()
+            }
+        } as any;
+
+        // Mock ServiceTreeRoot
+        mockRoot = {
+            client: {
+                backend: {
+                    createOrUpdate: sandbox.stub().resolves()
+                }
+            },
+            credentials: {} as any,
+            environment: {
+                resourceManagerEndpointUrl: 'https://management.azure.com'
+            },
+            subscriptionId: 'test-subscription-id',
+            resourceGroupName: 'test-resource-group',
+            serviceName: 'test-service'
+        } as any;
+
+        // Mock McpServersTreeItem
+        mockNode = {
+            root: mockRoot,
+            refresh: sandbox.stub().resolves()
+        } as any;
+
+        // Mock ApimService
+        mockApimService = sandbox.createStubInstance(ApimService);
+        sandbox.stub(ApimService.prototype, 'createMcpServer').callsFake(mockApimService.createMcpServer);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('successful flow', () => {
+        it('should successfully create passthrough MCP server with SSE protocol', async () => {
+            // Arrange
+            setupSuccessfulUserInputs('SSE');
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            verifyUserInputSequence();
+            verifyBackendCreation('https://example.com/mcp');
+            verifyMcpServerCreationWithSSE();
+            verifySuccessMessage('SSE');
+        });
+
+        it('should successfully create passthrough MCP server with Streamable HTTP protocol', async () => {
+            // Arrange
+            setupSuccessfulUserInputs('Streamable HTTP');
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            verifyUserInputSequence(false); // No SSE endpoints for Streamable HTTP
+            verifyBackendCreation('https://example.com/mcp');
+            verifyMcpServerCreationWithoutSSE();
+            verifySuccessMessage('Streamable HTTP');
+        });
+    });
+
+    describe('early return scenarios', () => {
+        it('should return early when node is undefined', async () => {
+            // Act
+            await passthroughMcpServer(mockContext, undefined);
+
+            // Assert
+            expect((mockContext.ui.showInputBox as sinon.SinonStub).notCalled).to.be.true;
+            expect((mockContext.ui.showQuickPick as sinon.SinonStub).notCalled).to.be.true;
+        });
+    });
+
+    describe('user cancellation scenarios', () => {
+        it('should handle user cancellation during server name input', async () => {
+            // Arrange
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .onFirstCall()
+                .rejects(new UserCancelledError());
+
+            // Act & Assert
+            try {
+                await passthroughMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown UserCancelledError');
+            } catch (error) {
+                expect(error).to.be.instanceOf(UserCancelledError);
+            }
+        });
+
+        it('should handle user cancellation during protocol selection', async () => {
+            // Arrange
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .onCall(0).resolves('test-server')
+                .onCall(1).resolves('Test Server');
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .rejects(new UserCancelledError());
+
+            // Act & Assert
+            try {
+                await passthroughMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown UserCancelledError');
+            } catch (error) {
+                expect(error).to.be.instanceOf(UserCancelledError);
+            }
+        });
+    });
+
+    describe('input validation', () => {
+        it('should validate server name input', async () => {
+            // Arrange
+            setupInputBoxForValidation(0);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const inputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(0);
+            const validateInput = inputBoxCall.args[0].validateInput;
+            
+            expect(validateInput('')).to.equal('Name is required');
+            expect(validateInput('   ')).to.equal('Name is required');
+            expect(validateInput('valid-name')).to.be.undefined;
+        });
+
+        it('should validate display name input', async () => {
+            // Arrange
+            setupInputBoxForValidation(1);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const inputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(1);
+            const validateInput = inputBoxCall.args[0].validateInput;
+            
+            expect(validateInput('')).to.equal('Display name is required');
+            expect(validateInput('   ')).to.equal('Display name is required');
+            expect(validateInput('valid-display-name')).to.be.undefined;
+        });
+
+        it('should validate server URL input', async () => {
+            // Arrange
+            setupInputBoxForValidation(2);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const inputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(2);
+            const validateInput = inputBoxCall.args[0].validateInput;
+            
+            expect(validateInput('')).to.equal('URL is required');
+            expect(validateInput('   ')).to.equal('URL is required');
+            expect(validateInput('invalid-url')).to.equal('Please enter a valid URL starting with http:// or https://');
+            expect(validateInput('ftp://example.com')).to.equal('Please enter a valid URL starting with http:// or https://');
+            expect(validateInput('http://example.com')).to.be.undefined;
+            expect(validateInput('https://example.com')).to.be.undefined;
+        });
+
+        it('should validate API URL suffix input', async () => {
+            // Arrange
+            setupInputBoxForValidation(3);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const inputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(3);
+            const validateInput = inputBoxCall.args[0].validateInput;
+            
+            expect(validateInput('')).to.equal('API URL suffix is required');
+            expect(validateInput('   ')).to.equal('API URL suffix is required');
+            expect(validateInput('valid-suffix')).to.be.undefined;
+        });
+
+        it('should validate SSE endpoint input for SSE protocol', async () => {
+            // Arrange
+            const inputBoxStub = mockContext.ui.showInputBox as sinon.SinonStub;
+            inputBoxStub
+                .onCall(0).resolves('test-server') // Server name
+                .onCall(1).resolves('Test Server') // Display name
+                .onCall(2).resolves('https://example.com/mcp') // Server URL
+                .onCall(3).resolves('test-api-suffix') // API URL suffix
+                .onCall(4).resolves('/sse') // SSE endpoint
+                .onCall(5).resolves('/messages'); // Messages endpoint
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .resolves({ label: 'SSE', description: 'Server-Sent Events' });
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const inputBoxCall = inputBoxStub.getCall(4);
+            const validateInput = inputBoxCall.args[0].validateInput;
+            
+            expect(validateInput('')).to.equal('SSE endpoint is required');
+            expect(validateInput('   ')).to.equal('SSE endpoint is required');
+            expect(validateInput('/sse')).to.be.undefined;
+        });
+
+        it('should validate messages endpoint input for SSE protocol', async () => {
+            // Arrange
+            setupSuccessfulUserInputs('SSE');
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const inputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(5);
+            const validateInput = inputBoxCall.args[0].validateInput;
+            
+            expect(validateInput('')).to.equal('Messages endpoint is required');
+            expect(validateInput('   ')).to.equal('Messages endpoint is required');
+            expect(validateInput('/messages')).to.be.undefined;
+        });
+    });
+
+    describe('error handling', () => {
+        it('should handle general errors and compose error message', async () => {
+            // Arrange
+            const originalError = new Error('Something went wrong');
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .onFirstCall()
+                .rejects(originalError);
+
+            // Act & Assert
+            try {
+                await passthroughMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown error');
+            } catch (error) {
+                expect(error.message).to.equal('Failed to proxy MCP server: Something went wrong');
+            }
+        });
+
+        it('should handle backend creation error', async () => {
+            // Arrange
+            setupSuccessfulUserInputs('SSE');
+            const backendError = new Error('Backend creation failed');
+            mockVscodeWindowProgress
+                .onFirstCall()
+                .callsFake((_options, _callback) => {
+                    throw backendError;
+                });
+
+            // Act & Assert
+            try {
+                await passthroughMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown error');
+            } catch (error) {
+                expect(error.message).to.equal('Failed to proxy MCP server: Backend creation failed');
+            }
+        });
+
+        it('should handle MCP server creation error', async () => {
+            // Arrange
+            setupSuccessfulUserInputs('SSE');
+            mockVscodeWindowProgress
+                .onFirstCall()
+                .callsFake((_options, callback) => callback({})); // Backend creation succeeds
+            
+            const mcpServerError = new Error('MCP server creation failed');
+            mockVscodeWindowProgress
+                .onSecondCall()
+                .callsFake((_options, _callback) => {
+                    throw mcpServerError;
+                });
+
+            // Act & Assert
+            try {
+                await passthroughMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown error');
+            } catch (error) {
+                expect(error.message).to.equal('Failed to proxy MCP server: MCP server creation failed');
+            }
+        });
+    });
+
+    describe('backend creation', () => {
+        it('should create backend with correct contract', async () => {
+            // Arrange
+            setupSuccessfulUserInputs('SSE');
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await passthroughMcpServer(mockContext, mockNode);
+
+            // Assert
+            const createOrUpdateCall = mockRoot.client.backend.createOrUpdate as sinon.SinonStub;
+            expect(createOrUpdateCall.calledOnce).to.be.true;
+            
+            const [resourceGroup, serviceName, backendName, backendContract] = createOrUpdateCall.getCall(0).args;
+            expect(resourceGroup).to.equal('test-resource-group');
+            expect(serviceName).to.equal('test-service');
+            expect(backendName).to.be.a('string');
+            expect(backendName.length).to.be.greaterThan(0);
+            
+            const expectedContract: BackendContract = {
+                url: 'https://example.com/mcp',
+                protocol: 'http'
+            };
+            expect(backendContract).to.deep.equal(expectedContract);
+        });
+    });
+
+    // Helper functions
+    function setupSuccessfulUserInputs(protocol: 'SSE' | 'Streamable HTTP'): void {
+        const inputBoxStub = mockContext.ui.showInputBox as sinon.SinonStub;
+        
+        inputBoxStub
+            .onCall(0).resolves('test-server') // Server name
+            .onCall(1).resolves('Test Server') // Display name
+            .onCall(2).resolves('https://example.com/mcp') // Server URL
+            .onCall(3).resolves('test-api-suffix'); // API URL suffix
+
+        if (protocol === 'SSE') {
+            inputBoxStub
+                .onCall(4).resolves('/sse') // SSE endpoint
+                .onCall(5).resolves('/messages'); // Messages endpoint
+        }
+
+        (mockContext.ui.showQuickPick as sinon.SinonStub)
+            .resolves({ 
+                label: protocol, 
+                description: protocol === 'SSE' ? 'Server-Sent Events' : 'Streamable HTTP protocol'
+            });
+    }
+
+    function setupInputBoxForValidation(callIndex: number): void {
+        const inputBoxStub = mockContext.ui.showInputBox as sinon.SinonStub;
+        
+        // Set up other calls to return valid values
+        inputBoxStub.onCall(0).resolves('test-server');
+        inputBoxStub.onCall(1).resolves('Test Server');
+        inputBoxStub.onCall(2).resolves('https://example.com/mcp');
+        inputBoxStub.onCall(3).resolves('test-api-suffix');
+        inputBoxStub.onCall(4).resolves('/sse');
+        inputBoxStub.onCall(5).resolves('/messages');
+
+        // The specific call we want to test validation for
+        inputBoxStub.onCall(callIndex).callThrough();
+
+        (mockContext.ui.showQuickPick as sinon.SinonStub)
+            .resolves({ label: 'Streamable HTTP', description: 'Streamable HTTP protocol' });
+
+        mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+        mockApimService.createMcpServer.resolves({} as any);
+    }
+
+    function verifyUserInputSequence(includeSSEEndpoints = true): void {
+        const inputBoxStub = mockContext.ui.showInputBox as sinon.SinonStub;
+        const quickPickStub = mockContext.ui.showQuickPick as sinon.SinonStub;
+        
+        const expectedCalls = includeSSEEndpoints ? 6 : 4;
+        expect(inputBoxStub.callCount).to.equal(expectedCalls);
+        expect(quickPickStub.calledOnce).to.be.true;
+    }
+
+    function verifyBackendCreation(expectedUrl: string): void {
+        const createOrUpdateCall = mockRoot.client.backend.createOrUpdate as sinon.SinonStub;
+        expect(createOrUpdateCall.calledOnce).to.be.true;
+        
+        const backendContract = createOrUpdateCall.getCall(0).args[3];
+        expect(backendContract.url).to.equal(expectedUrl);
+        expect(backendContract.protocol).to.equal('http');
+    }
+
+    function verifyMcpServerCreationWithSSE(): void {
+        expect(mockApimService.createMcpServer.calledOnce).to.be.true;
+        
+        const [mcpServerName, mcpServerPayload] = mockApimService.createMcpServer.getCall(0).args;
+        expect(mcpServerName).to.equal('test-server');
+        expect(mcpServerPayload.properties.displayName).to.equal('Test Server');
+        expect(mcpServerPayload.properties.path).to.equal('test-api-suffix');
+        expect(mcpServerPayload.properties.type).to.equal('mcp');
+        expect(mcpServerPayload.properties.backendId).to.be.a('string');
+        expect(mcpServerPayload.properties.mcpProperties).to.deep.equal({
+            transportType: 'sse',
+            endpoints: {
+                sse: {
+                    method: 'GET',
+                    uriTemplate: '/sse'
+                },
+                messages: {
+                    method: 'POST',
+                    uriTemplate: '/messages'
+                }
+            }
+        });
+    }
+
+    function verifyMcpServerCreationWithoutSSE(): void {
+        expect(mockApimService.createMcpServer.calledOnce).to.be.true;
+        
+        const [mcpServerName, mcpServerPayload] = mockApimService.createMcpServer.getCall(0).args;
+        expect(mcpServerName).to.equal('test-server');
+        expect(mcpServerPayload.properties.displayName).to.equal('Test Server');
+        expect(mcpServerPayload.properties.path).to.equal('test-api-suffix');
+        expect(mcpServerPayload.properties.type).to.equal('mcp');
+        expect(mcpServerPayload.properties.backendId).to.be.a('string');
+        expect(mcpServerPayload.properties.mcpProperties).to.be.undefined;
+    }
+
+    function verifySuccessMessage(protocol: string): void {
+        expect(mockVscodeWindow.calledOnce).to.be.true;
+        expect(mockVscodeWindow.calledWith(
+            `Successfully proxied MCP server "Test Server" with ${protocol} protocol.`
+        )).to.be.true;
+        expect((mockNode.refresh as sinon.SinonStub).calledOnce).to.be.true;
+    }
+});

--- a/test/transformApiToMcpServer.test.ts
+++ b/test/transformApiToMcpServer.test.ts
@@ -1,0 +1,658 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import { uiUtils } from '@microsoft/vscode-azext-azureutils';
+import { ApiContract, OperationContract } from '@azure/arm-apimanagement';
+import { transformApiToMcpServer } from '../src/commands/transformApiToMcpServer';
+import { McpServersTreeItem } from '../src/explorer/McpServersTreeItem';
+import { ApimService } from '../src/azure/apim/ApimService';
+import { IServiceTreeRoot } from '../src/explorer/IServiceTreeRoot';
+
+describe('transformApiToMcpServer', () => {
+    let sandbox: sinon.SinonSandbox;
+    let mockContext: IActionContext;
+    let mockNode: McpServersTreeItem;
+    let mockRoot: IServiceTreeRoot;
+    let mockUiUtils: sinon.SinonStub;
+    let mockApimService: sinon.SinonStubbedInstance<ApimService>;
+    let mockVscodeWindow: sinon.SinonStub;
+    let mockVscodeWindowProgress: sinon.SinonStub;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        // Mock VSCode window methods
+        mockVscodeWindow = sandbox.stub(vscode.window, 'showInformationMessage');
+        mockVscodeWindowProgress = sandbox.stub(vscode.window, 'withProgress');
+
+        // Mock ActionContext
+        mockContext = {
+            ui: {
+                showQuickPick: sandbox.stub(),
+                showInputBox: sandbox.stub()
+            }
+        } as any;
+
+        // Mock ServiceTreeRoot
+        mockRoot = {
+            client: {
+                api: {
+                    listByService: sandbox.stub()
+                },
+                apiOperation: {
+                    listByApi: sandbox.stub()
+                }
+            },
+            credentials: {} as any,
+            environment: {
+                resourceManagerEndpointUrl: 'https://management.azure.com'
+            },
+            subscriptionId: 'test-subscription-id',
+            resourceGroupName: 'test-resource-group',
+            serviceName: 'test-service'
+        } as any;
+
+        // Mock McpServersTreeItem
+        mockNode = {
+            root: mockRoot,
+            refresh: sandbox.stub().resolves()
+        } as any;
+
+        // Mock uiUtils.listAllIterator
+        mockUiUtils = sandbox.stub(uiUtils, 'listAllIterator');
+
+        // Mock ApimService
+        mockApimService = sandbox.createStubInstance(ApimService);
+        sandbox.stub(ApimService.prototype, 'createMcpServer').callsFake(mockApimService.createMcpServer);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('successful flow', () => {
+        it('should successfully transform API to MCP server', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API',
+                path: 'test-path'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    description: 'Test operation 1',
+                    method: 'GET'
+                },
+                {
+                    name: 'operation2',
+                    displayName: 'Operation 2',
+                    description: 'Test operation 2',
+                    method: 'POST'
+                }
+            ];
+
+            // Mock API listing
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            
+            // Mock operation listing
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            // Mock user selections
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([
+                    { label: 'Operation 1', operation: mockOperations[0] },
+                    { label: 'Operation 2', operation: mockOperations[1] }
+                ]);
+
+            // Mock user input for API URL suffix
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('test-path-mcp');
+
+            // Mock progress dialog
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+
+            // Mock ApimService.createMcpServer
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            expect(mockUiUtils.calledTwice).to.be.true;
+            expect((mockContext.ui.showQuickPick as sinon.SinonStub).calledTwice).to.be.true;
+            expect((mockContext.ui.showInputBox as sinon.SinonStub).calledOnce).to.be.true;
+            expect(mockApimService.createMcpServer.calledOnce).to.be.true;
+            expect(mockVscodeWindow.calledOnce).to.be.true;
+            expect(mockVscodeWindow.calledWith('Successfully created MCP server from API "Test API".')).to.be.true;
+
+            // Verify the MCP server payload
+            const createMcpServerCall = mockApimService.createMcpServer.getCall(0);
+            const mcpApiName = createMcpServerCall.args[0];
+            const mcpServerPayload = createMcpServerCall.args[1];
+
+            expect(mcpApiName).to.equal('test-api-mcp');
+            expect(mcpServerPayload.properties.displayName).to.equal('Test API MCP');
+            expect(mcpServerPayload.properties.path).to.equal('test-path-mcp');
+            expect(mcpServerPayload.properties.mcpTools).to.have.length(2);
+            expect(mcpServerPayload.properties.mcpTools[0].name).to.equal('operation1');
+            expect(mcpServerPayload.properties.mcpTools[1].name).to.equal('operation2');
+        });
+
+        it('should use default API URL suffix when API has no path', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+                // No path property
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    description: 'Test operation 1',
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([{ label: 'Operation 1', operation: mockOperations[0] }]);
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('test-api-mcp');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            const showInputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(0);
+            const inputBoxOptions = showInputBoxCall.args[0];
+            expect(inputBoxOptions.value).to.equal('test-api-mcp');
+        });
+    });
+
+    describe('early return scenarios', () => {
+        it('should return early when node is undefined', async () => {
+            // Act
+            await transformApiToMcpServer(mockContext, undefined);
+
+            // Assert
+            expect(mockUiUtils.notCalled).to.be.true;
+            expect((mockContext.ui.showQuickPick as sinon.SinonStub).notCalled).to.be.true;
+        });
+
+        it('should return early when no APIs are found', async () => {
+            // Arrange
+            mockUiUtils.onFirstCall().resolves([]);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            expect(mockUiUtils.calledOnce).to.be.true;
+            expect(mockVscodeWindow.calledWith('No APIs found in the current API Management service.')).to.be.true;
+            expect((mockContext.ui.showQuickPick as sinon.SinonStub).notCalled).to.be.true;
+        });
+
+        it('should return early when user cancels API selection', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .rejects(new UserCancelledError()); // User cancelled
+
+            // Act & Assert
+            try {
+                await transformApiToMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown UserCancelledError');
+            } catch (error) {
+                expect(error).to.be.instanceOf(UserCancelledError);
+            }
+        });
+
+        it('should return early when no operations are found', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves([]);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            expect(mockUiUtils.calledTwice).to.be.true;
+            expect(mockVscodeWindow.calledWith('No operations found in API "Test API".')).to.be.true;
+            expect((mockContext.ui.showQuickPick as sinon.SinonStub).calledOnce).to.be.true;
+        });
+
+        it('should return early when user cancels operation selection', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .rejects(new UserCancelledError()); // User cancelled
+
+            // Act & Assert
+            try {
+                await transformApiToMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown UserCancelledError');
+            } catch (error) {
+                expect(error).to.be.instanceOf(UserCancelledError);
+            }
+        });
+
+        it('should return early when no operations are selected', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([]); // Empty selection
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            expect(mockUiUtils.calledTwice).to.be.true;
+            expect((mockContext.ui.showQuickPick as sinon.SinonStub).calledTwice).to.be.true;
+            expect((mockContext.ui.showInputBox as sinon.SinonStub).notCalled).to.be.true;
+        });
+    });
+
+    describe('input validation', () => {
+        it('should validate API URL suffix input', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([{ label: 'Operation 1', operation: mockOperations[0] }]);
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('valid-suffix');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            const showInputBoxCall = (mockContext.ui.showInputBox as sinon.SinonStub).getCall(0);
+            const inputBoxOptions = showInputBoxCall.args[0];
+            
+            // Test validation function
+            const validateInput = inputBoxOptions.validateInput;
+            expect(validateInput('')).to.equal('API URL suffix is required');
+            expect(validateInput('   ')).to.equal('API URL suffix is required');
+            expect(validateInput('valid-input')).to.be.undefined;
+        });
+    });
+
+    describe('error handling', () => {
+        it('should handle general errors and compose error message', async () => {
+            // Arrange
+            const originalError = new Error('Something went wrong');
+            mockUiUtils.onFirstCall().rejects(originalError);
+
+            // Act & Assert
+            try {
+                await transformApiToMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown error');
+            } catch (error) {
+                expect(error.message).to.equal('Failed to transform API to MCP server: Something went wrong');
+            }
+        });
+
+        it('should handle createMcpServer error', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([{ label: 'Operation 1', operation: mockOperations[0] }]);
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('test-suffix');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            
+            const createError = new Error('Create MCP server failed');
+            mockApimService.createMcpServer.rejects(createError);
+
+            // Act & Assert
+            try {
+                await transformApiToMcpServer(mockContext, mockNode);
+                expect.fail('Should have thrown error');
+            } catch (error) {
+                expect(error.message).to.equal('Failed to transform API to MCP server: Create MCP server failed');
+            }
+        });
+    });
+
+    describe('operation formatting', () => {
+        it('should format operations with description correctly', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    description: 'This is a test operation',
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+
+            let operationQuickPickItems: any[] = [];
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .callsFake((items) => {
+                    operationQuickPickItems = items;
+                    return Promise.resolve([{ label: 'Operation 1', operation: mockOperations[0] }]);
+                });
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('test-suffix');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            expect(operationQuickPickItems[0].description).to.equal('GET - This is a test operation');
+        });
+
+        it('should format operations without description correctly', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    method: 'POST'
+                    // No description
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+
+            let operationQuickPickItems: any[] = [];
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .callsFake((items) => {
+                    operationQuickPickItems = items;
+                    return Promise.resolve([{ label: 'Operation 1', operation: mockOperations[0] }]);
+                });
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('test-suffix');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            expect(operationQuickPickItems[0].description).to.equal('POST');
+        });
+    });
+
+    describe('MCP payload construction', () => {
+        it('should construct correct MCP server payload', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'my-test-api',
+                displayName: 'My Test API',
+                path: 'custom-path'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'getUsers',
+                    displayName: 'Get Users',
+                    description: 'Retrieve all users',
+                    method: 'GET'
+                },
+                {
+                    name: 'createUser',
+                    displayName: 'Create User',
+                    description: 'Create a new user',
+                    method: 'POST'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'My Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([
+                    { label: 'Get Users', operation: mockOperations[0] },
+                    { label: 'Create User', operation: mockOperations[1] }
+                ]);
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('my-custom-mcp-suffix');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            const createMcpServerCall = mockApimService.createMcpServer.getCall(0);
+            const mcpApiName = createMcpServerCall.args[0];
+            const mcpServerPayload = createMcpServerCall.args[1];
+
+            expect(mcpApiName).to.equal('my-test-api-mcp');
+            
+            const expectedPayload = {
+                id: `/subscriptions/test-subscription-id/resourceGroups/test-resource-group/providers/Microsoft.ApiManagement/service/test-service/apis/my-test-api-mcp`,
+                name: 'my-test-api-mcp',
+                properties: {
+                    type: 'mcp',
+                    displayName: 'My Test API MCP',
+                    subscriptionRequired: false,
+                    path: 'my-custom-mcp-suffix',
+                    protocols: ['http', 'https'],
+                    mcpTools: [
+                        {
+                            name: 'getUsers',
+                            description: 'Retrieve all users',
+                            operationId: `/subscriptions/test-subscription-id/resourceGroups/test-resource-group/providers/Microsoft.ApiManagement/service/test-service/apis/my-test-api/operations/getUsers`
+                        },
+                        {
+                            name: 'createUser',
+                            description: 'Create a new user',
+                            operationId: `/subscriptions/test-subscription-id/resourceGroups/test-resource-group/providers/Microsoft.ApiManagement/service/test-service/apis/my-test-api/operations/createUser`
+                        }
+                    ]
+                }
+            };
+
+            expect(mcpServerPayload).to.deep.equal(expectedPayload);
+        });
+
+        it('should handle operations with empty description', async () => {
+            // Arrange
+            const mockApi: ApiContract = {
+                name: 'test-api',
+                displayName: 'Test API'
+            };
+
+            const mockOperations: OperationContract[] = [
+                {
+                    name: 'operation1',
+                    displayName: 'Operation 1',
+                    description: '', // Empty description
+                    method: 'GET'
+                }
+            ];
+
+            mockUiUtils.onFirstCall().resolves([mockApi]);
+            mockUiUtils.onSecondCall().resolves(mockOperations);
+
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onFirstCall()
+                .resolves({ label: 'Test API', api: mockApi });
+            
+            (mockContext.ui.showQuickPick as sinon.SinonStub)
+                .onSecondCall()
+                .resolves([{ label: 'Operation 1', operation: mockOperations[0] }]);
+
+            (mockContext.ui.showInputBox as sinon.SinonStub)
+                .resolves('test-suffix');
+
+            mockVscodeWindowProgress.callsFake((_options, callback) => callback({}));
+            mockApimService.createMcpServer.resolves({} as any);
+
+            // Act
+            await transformApiToMcpServer(mockContext, mockNode);
+
+            // Assert
+            const createMcpServerCall = mockApimService.createMcpServer.getCall(0);
+            const mcpServerPayload = createMcpServerCall.args[1];
+            
+            expect(mcpServerPayload.properties.mcpTools[0].description).to.equal('');
+        });
+    });
+});


### PR DESCRIPTION
1. Create transformative MCP server, which transforms some operations of an existing API in APIM to a MCP server
2. Create passthrough MCP server, which proxies an existing MCP server through APIM, allowing developers add policies for the MCP server. This supports both SSE and Streamable HTTP protocol.