### PR TITLE
feat: move explain/draft APIM policy menus to APIM menu group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to the "Azure Api Management VS Code" extension will be docu
 - **Create MCP server**: You can now create `transformative` and `passthrough` MCP server in APIM. `transformative` transforms an existing API in APIM to MCP server by selecting a series of operations to be exposed by the MCP server. `passthrough` exposes your existing MCP server through APIM, allowing you to add additional capabilities provided by APIM to your MCP server.
 ![CreateMCP](https://github.com/user-attachments/assets/973c4194-e40b-49b4-921b-42eaf2c7a6ec)
 
+### Updates
+
+- Moved `Explain APIM Policies` and `Draft APIM Policies` context menu from `Copilot` group to `Azure API Management` group
+
 ## 1.2.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -593,6 +593,12 @@
                 }
             ]
         },
+        "submenus": [
+            {
+                "id": "azureApiManagement.submenu",
+                "label": "Azure API Management"
+            }
+        ],
         "menus": {
             "editor/title": [
                 {
@@ -625,6 +631,13 @@
                 {
                     "command": "azureApiManagement.passthroughMcpServer",
                     "when": "never"
+                }
+            ],
+            "editor/context": [
+                {
+                    "submenu": "azureApiManagement.submenu",
+                    "when": "resourceExtname == '.xml'",
+                    "group": "apiManagement"
                 }
             ],
             "view/title": [
@@ -911,16 +924,14 @@
                     "group": "1@1"
                 }
             ],
-            "copilot": [
+            "azureApiManagement.submenu": [
                 {
                     "command": "azureApiManagement.explainPolicy",
-                    "when": "github.copilot-chat.activated && resourceExtname == '.xml'",
-                    "group": "apiManagement"
+                    "when": "github.copilot-chat.activated && resourceExtname == '.xml'"
                 },
                 {
                     "command": "azureApiManagement.draftPolicy",
-                    "when": "github.copilot-chat.activated && resourceExtname == '.xml'",
-                    "group": "apiManagement"
+                    "when": "github.copilot-chat.activated && resourceExtname == '.xml'"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -637,7 +637,7 @@
                 {
                     "submenu": "azureApiManagement.submenu",
                     "when": "resourceExtname == '.xml'",
-                    "group": "apiManagement"
+                    "group": "azureApiManagement"
                 }
             ],
             "view/title": [


### PR DESCRIPTION
We cannot add `explain APIM policy` and `draft APIM policy` menu to `Copilot` menu group in latest VS Code version. Move these 2 menus to APIM's own menu group to workaround this issue.